### PR TITLE
Field additional data

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,9 +129,13 @@ const cycleCount = ch22System.run(targetCycles);
 ```js
 /**
  * get buffer of snapshotted scanline data
- * each row is 801 bytes:
+ * each row is 827 bytes:
  * - 1 byte     - 0 => empty line, 1 => line has data
  * - 800 bytes  - snapshot of up to 800 bytes of video memory for the scanline
+ * - 2 bytes    - crtcAddress of snapshot
+ * - 8 bytes    - d0 64bit additional data passed from snapshot
+ * - 8 bytes    - d1 64bit additional data passed from snapshot
+ * - 8 bytes    - d2 64bit additional data passed from snapshot
  */
 const memory = new Uint8Array(
   wasmMemory.buffer,
@@ -140,14 +144,28 @@ const memory = new Uint8Array(
 );
 
 /**
+ * clear the buffer
+ */
+ch22System.video_field_clear();
+
+/**
  * add a snapshot of the current video memory
  * for a given CRTC address and CRTC length
  * - bufferLine: destination line in buffer for snapshot
  * - crtcAddress: crtc address for snapshot
  * - crtcLength: length of crtc region for snapshot
+ * - d0, d1, d2: 3x 64bit data to be stored with the snapshot
  * - isTeletext: crtc region should match this, if not snapshot a blank link
  */
-ch22System.snapshot_char_data(bufferLine, crtcAddress, crtcLength, isTeletext);
+ch22System.snapshot_char_data(
+  bufferLine,
+  crtcAddress,
+  crtcLength,
+  d0,
+  d1,
+  d2,
+  isTeletext,
+);
 ```
 
 ## 🧪 Running tests

--- a/ch22-core/src/system/core.rs
+++ b/ch22-core/src/system/core.rs
@@ -9,7 +9,7 @@ use super::{
 };
 use crate::address_spaces::{IOSpace, Ram, Rom};
 use crate::devices::{RomSelect, TimerDeviceList};
-use crate::video::{CRTCRangeType, Field};
+use crate::video::{CRTCRangeType, Field, FieldLineAdditionalData};
 use crate::{cpu::Cpu, devices::DeviceSpeed};
 
 #[derive(Default)]
@@ -63,6 +63,7 @@ impl Core {
         row_index: usize,
         crtc_address: u16,
         crtc_length: u8,
+        field_line_additional_data: FieldLineAdditionalData,
         required_type: CRTCRangeType,
     ) {
         self.video_field.snapshot_char_data(
@@ -70,6 +71,7 @@ impl Core {
             crtc_address,
             crtc_length,
             self.ic32_latch.get(),
+            field_line_additional_data,
             required_type,
             |range| self.ram.slice(range),
         );

--- a/ch22-core/src/system/system_ffi.rs
+++ b/ch22-core/src/system/system_ffi.rs
@@ -9,7 +9,7 @@ use crate::devices::{
     DeviceSpeed, IODeviceID, JsIODevice, JsTimerDevice, StaticDevice, TimerDeviceID,
 };
 use crate::utils;
-use crate::video::{CRTCRangeType, Field};
+use crate::video::{CRTCRangeType, Field, FieldLineAdditionalData};
 
 #[wasm_bindgen(js_name = System)]
 #[derive(Default)]
@@ -37,17 +37,25 @@ impl SystemFfi {
         size_of::<Field>()
     }
 
+    pub fn video_field_clear(&mut self) {
+        self.core.video_field.clear();
+    }
+
     pub fn snapshot_char_data(
         &mut self,
         row_index: usize,
         crtc_address: u16,
         crtc_length: u8,
+        d0: u64,
+        d1: u64,
+        d2: u64,
         is_teletext: bool,
     ) {
         self.core.snapshot_char_data(
             row_index,
             crtc_address,
             crtc_length,
+            FieldLineAdditionalData { d0, d1, d2 },
             match is_teletext {
                 true => CRTCRangeType::Teletext,
                 false => CRTCRangeType::HiRes,

--- a/ch22-core/src/video.rs
+++ b/ch22-core/src/video.rs
@@ -1,5 +1,5 @@
 mod field_data;
 mod video_memory_access;
 
-pub use field_data::Field;
+pub use field_data::{Field, FieldLineAdditionalData};
 pub use video_memory_access::{CRTCRangeType, VideoMemoryAccess};

--- a/ch22-core/src/video/field_data.rs
+++ b/ch22-core/src/video/field_data.rs
@@ -2,7 +2,7 @@ use crate::video::{CRTCRangeType, VideoMemoryAccess};
 
 const MAX_LINES: usize = 320;
 
-#[repr(C)]
+#[repr(C, packed)]
 pub struct Field {
     lines: [Option<FieldLine>; MAX_LINES],
 }
@@ -16,26 +16,31 @@ impl Default for Field {
 }
 
 impl Field {
+    pub fn clear(&mut self) {
+        self.lines = std::array::from_fn(|_| None);
+    }
+
     pub fn snapshot_char_data<'a, F>(
         &mut self,
         row_index: usize,
         crtc_address: u16,
         crtc_length: u8,
         ic32_latch: u8,
+        additional_data: FieldLineAdditionalData,
         required_type: CRTCRangeType,
         get_buffer: F,
     ) where
         F: Fn(std::ops::Range<u16>) -> &'a [u8],
     {
         if crtc_length == 0 {
-            self.set_blank_line(row_index);
+            self.clear_line(row_index);
             return;
         }
 
         let video_type = VideoMemoryAccess::get_crtc_range_type(crtc_address, crtc_length);
 
         if video_type != required_type {
-            self.set_blank_line(row_index);
+            self.clear_line(row_index);
             return;
         }
 
@@ -45,22 +50,32 @@ impl Field {
         let first_ram_slice = get_buffer(first_ram_range);
         let second_ram_slice = second_ram_range.map(get_buffer);
 
-        self.set_char_data_line(row_index, first_ram_slice, second_ram_slice);
+        self.set_line(
+            row_index,
+            first_ram_slice,
+            second_ram_slice,
+            crtc_address,
+            additional_data,
+        );
     }
 
-    pub fn set_blank_line(&mut self, row_index: usize) {
+    pub fn clear_line(&mut self, row_index: usize) {
         self.lines[row_index] = None;
     }
 
-    pub fn set_char_data_line(
+    pub fn set_line(
         &mut self,
         row_index: usize,
         first_slice: &[u8],
         second_slice: Option<&[u8]>,
+        crtc_address: u16,
+        additional_data: FieldLineAdditionalData,
     ) {
         let row = self.lines[row_index].get_or_insert_default();
 
         row.set_char_data(first_slice, second_slice);
+        row.crtc_address = crtc_address;
+        row.additional_data = additional_data;
     }
 }
 
@@ -68,9 +83,11 @@ const MAX_CHARS: usize = 100;
 const MAX_BYTES_PER_CHAR: usize = 8;
 const MAX_CHAR_DATA: usize = MAX_CHARS * MAX_BYTES_PER_CHAR;
 
-#[repr(C)]
+#[repr(C, packed)]
 struct FieldLine {
     char_data: [u8; MAX_CHAR_DATA],
+    crtc_address: u16,
+    additional_data: FieldLineAdditionalData,
 }
 
 impl FieldLine {
@@ -99,6 +116,16 @@ impl Default for FieldLine {
     fn default() -> Self {
         FieldLine {
             char_data: [0; MAX_CHAR_DATA],
+            crtc_address: 0,
+            additional_data: FieldLineAdditionalData::default(),
         }
     }
+}
+
+#[repr(C, packed)]
+#[derive(Default)]
+pub struct FieldLineAdditionalData {
+    pub d0: u64,
+    pub d1: u64,
+    pub d2: u64,
 }


### PR DESCRIPTION
- video_field_clear function
- addition of extra data in video_field snapshots
  - crtc_address
  - d0, d1, d2 - 3x 64bit general purpose additional data supplied by caller of snapshot_char_data
- minor renaming inside Field 