### PR TITLE
CRTC + video refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,10 +126,10 @@ ch22System.add_static_device(addresses, readValue, oneMhz, panicOnWrite);
 ch22System.reset();
 
 /**
- * executes instructions until targetCycles is reached
+ * executes instructions until until the next field is ready for render
  * returns number of cycles
  */
-const cycleCount = ch22System.run(targetCycles);
+const cycleCount = ch22System.run_one_field();
 ```
 
 ### Snapshotting Video memory into a buffer

--- a/README.md
+++ b/README.md
@@ -172,20 +172,6 @@ ch22System.video_field_clear();
  * increment field count (used by cursor flash)
  */
 ch22System.inc_field_counter();
-
-/**
- * add a snapshot of the current video memory and registers
- * - lineIndex: line in buffer for snapshot
- * - crtcMemoryAddress: crtc address for snapshot
- * - crtcRasterAddress: line index relative to current character row for the even field
- * - crtcRasterAddress: line index relative to current character row for the odd field
- */
-ch22System.snapshot_scanline(
-  lineIndex,
-  crtcMemoryAddress,
-  crtcRasterAddressEvenField,
-  crtcRasterAddressOddField,
-);
 ```
 
 ### Rendering

--- a/README.md
+++ b/README.md
@@ -132,16 +132,6 @@ ch22System.reset();
 const cycleCount = ch22System.run(targetCycles);
 ```
 
-### Getting current state
-
-```js
-/**
- * get video registers
- * [r0,r1,r3,r4,r5,r6,r7,r8,r9,r12,r13,ula control] packed into u128
- */
-const videoRegisters = ch22System.get_partial_video_registers();
-```
-
 ### Snapshotting Video memory into a buffer
 
 ```js

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ ch22System.load_rom(bank, pagedRom);
 
 /**
  * register a callback to be called at certain cycles
- * - handleTrigger: (cycles: bigint): bigint
+ * - handleTrigger: (cycles: bigint) => bigint
  *   - cycles: machine cycles at time of callback
  *   - returns: the desired next value of cycles to be called encoded as a bigint
  */
@@ -75,11 +75,14 @@ ch22System.set_device_trigger(deviceId, cycles);
 /**
  * register callbacks for an IO device
  * - addresses: UInt16Array of addresses to register device for
- * - read: (address: number, cycles: bigint): bigint
+ * - read: (address: number, cycles: bigint) => bigint
  *   - returns: read value, next cycle sync and interrupt encoded as bigint
- * - write: (address: number, value: number, cycles: bigint): bigint
+ * - write: (address: number, value: number, cycles: bigint) => bigint
  *   - returns: next cycle sync and interrupt and optionally ic32_latch encoded as bigint
- * - handleTrigger: (address: number, value: number, cycles: bigint): bigint
+ * - onVsyncChange: ((vsync: boolean) => bigint) | null
+ *  - optional callback if device needs to know about vsync state changes
+ *  - returns: next cycle sync and interrupt encoded as bigint
+ * - handleTrigger: (address: number, value: number, cycles: bigint) => bigint
  *   - callback if sync is required
  *   - returns: next cycle sync and interrupt encoded as bigint
  * - flags:
@@ -92,6 +95,7 @@ const deviceId = ch22System.add_js_io_device(
   addresses,
   read,
   write,
+  onVsyncChange,
   handleTrigger,
   flags,
 );

--- a/README.md
+++ b/README.md
@@ -152,16 +152,6 @@ const memory = new Uint8Array(
   ch22System.video_field_start(),
   ch22System.video_field_size(),
 );
-
-/**
- * clear the buffer
- */
-ch22System.video_field_clear();
-
-/**
- * increment field count (used by cursor flash)
- */
-ch22System.inc_field_counter();
 ```
 
 ### Rendering

--- a/ch22-core/src/address_spaces/io_space.rs
+++ b/ch22-core/src/address_spaces/io_space.rs
@@ -67,6 +67,12 @@ impl IOSpace {
             self.phase_2_data = None;
         }
     }
+
+    pub fn on_vsync_change(&mut self, vsync: bool) {
+        self.devices.for_each(|device| {
+            device.on_vsync_change(vsync);
+        });
+    }
 }
 
 pub fn access<F: FnOnce(u64) -> T, T>(access_fn: F, speed: &DeviceSpeed, clock: &mut Clock) -> T {

--- a/ch22-core/src/devices/io_device.rs
+++ b/ch22-core/src/devices/io_device.rs
@@ -5,6 +5,7 @@ pub trait IODevice {
     fn write(&mut self, _address: Word, _value: u8, _cycles: u64) -> bool {
         false
     }
+    fn on_vsync_change(&mut self, _vsync: bool) {}
     fn phase_2(&mut self, _address: Word, _value: u8, _cycles: u64) {}
     fn get_interrupt(&mut self, _cycles: u64) -> bool {
         false

--- a/ch22-core/src/devices/io_device_list.rs
+++ b/ch22-core/src/devices/io_device_list.rs
@@ -87,6 +87,12 @@ impl IODeviceList {
             })
             .map(|(_, device)| device)
     }
+
+    pub fn for_each<F: FnMut(&mut Box<dyn IODevice>)>(&mut self, mut callback: F) {
+        for device in self.device_list.iter_mut() {
+            callback(device);
+        }
+    }
 }
 
 pub struct IODeviceConfig {

--- a/ch22-core/src/devices/js_io_device.rs
+++ b/ch22-core/src/devices/js_io_device.rs
@@ -10,6 +10,7 @@ use super::io_device::IODevice;
 pub struct JsIODevice {
     read: Box<dyn Fn(u16, u64) -> u64>,
     write: Box<dyn Fn(u16, u8, u64) -> u64>,
+    on_vsync_change: Option<Box<dyn Fn(bool) -> u64>>,
     handle_trigger: Box<dyn Fn(u64) -> u64>,
     trigger: Option<u64>,
     interrupt: bool,
@@ -21,6 +22,7 @@ impl JsIODevice {
     pub fn new(
         js_read: Function,
         js_write: Function,
+        js_on_vsync_change: Option<Function>,
         js_handle_trigger: Function,
         phase_2_write: bool,
         ic32_latch: Rc<Cell<u8>>,
@@ -46,6 +48,16 @@ impl JsIODevice {
                 .expect("js_write error")
         });
 
+        let on_vsync_change = js_on_vsync_change.map(|js_on_vsync_change| {
+            Box::new(move |vsync: bool| {
+                js_on_vsync_change
+                    .call1(&JsValue::NULL, &vsync.into())
+                    .expect("js_on_vsync_change error")
+                    .try_into()
+                    .expect("js_on_vsync_change error")
+            }) as Box<dyn Fn(bool) -> u64>
+        });
+
         let handle_trigger = Box::new(move |cycles: u64| {
             js_handle_trigger
                 .call1(&JsValue::NULL, &cycles.into())
@@ -57,6 +69,7 @@ impl JsIODevice {
         JsIODevice {
             read,
             write,
+            on_vsync_change,
             handle_trigger,
             trigger: None,
             interrupt: false,
@@ -96,6 +109,12 @@ impl IODevice for JsIODevice {
 
     fn set_interrupt(&mut self, interrupt: bool) {
         self.interrupt = interrupt;
+    }
+
+    fn on_vsync_change(&mut self, vsync: bool) {
+        if let Some(on_vsync_change) = &self.on_vsync_change {
+            self.set_js_device_params((on_vsync_change)(vsync));
+        }
     }
 }
 

--- a/ch22-core/src/system/core.rs
+++ b/ch22-core/src/system/core.rs
@@ -84,6 +84,10 @@ impl Core {
         self.field_counter = self.field_counter.wrapping_add(1);
     }
 
+    pub fn on_vsync_change(&mut self, vsync: bool) {
+        self.io_space.on_vsync_change(vsync);
+    }
+
     pub fn snapshot_scanline(
         &mut self,
         line_index: usize,

--- a/ch22-core/src/system/core.rs
+++ b/ch22-core/src/system/core.rs
@@ -9,7 +9,7 @@ use super::{
 };
 use crate::address_spaces::{IOSpace, Ram, Rom};
 use crate::devices::{RomSelect, TimerDeviceList};
-use crate::video::{Video, VideoCRTCRegistersDevice, VideoULARegistersDevice};
+use crate::video::Video;
 use crate::{cpu::Cpu, devices::DeviceSpeed};
 
 #[derive(Default)]
@@ -33,14 +33,14 @@ impl Core {
             &[
                 0xfe00, 0xfe01, 0xfe02, 0xfe03, 0xfe04, 0xfe05, 0xfe06, 0xfe07,
             ],
-            Box::new(VideoCRTCRegistersDevice::new(self.video.registers.clone())),
+            Box::new(self.video.create_crtc_registers_device()),
             None,
             DeviceSpeed::OneMhz,
         );
 
         self.io_space.add_device(
             &[0xfe20, 0xfe21, 0xfe22, 0xfe23],
-            Box::new(VideoULARegistersDevice::new(self.video.registers.clone())),
+            Box::new(self.video.create_ula_registers_device()),
             None,
             DeviceSpeed::OneMhz,
         );
@@ -86,11 +86,7 @@ impl Core {
         loop {
             self.run(self.video.get_next_scanline_trigger());
 
-            let is_field_complete = self.video.process_scanline(
-                self.ic32_latch.get(),
-                |range| self.ram.slice(range),
-                |vsync| self.io_space.on_vsync_change(vsync),
-            );
+            let is_field_complete = self.process_scanline();
 
             if is_field_complete {
                 return self.cycles;
@@ -122,6 +118,14 @@ impl Core {
         };
 
         run_fn(&mut runner);
+    }
+
+    fn process_scanline(&mut self) -> bool {
+        self.video.process_scanline(
+            self.ic32_latch.get(),
+            |range| self.ram.slice(range),
+            |vsync| self.io_space.on_vsync_change(vsync),
+        )
     }
 }
 

--- a/ch22-core/src/system/core.rs
+++ b/ch22-core/src/system/core.rs
@@ -23,6 +23,7 @@ pub struct Core {
     pub io_space: IOSpace,
     pub video_field: Field,
     pub crtc: Crtc,
+    pub vsync: bool,
     pub ic32_latch: Rc<Cell<u8>>,
     pub field_counter: u8,
     pub rom_select_latch: Rc<Cell<usize>>,
@@ -94,24 +95,32 @@ impl Core {
     }
 
     pub fn process_scanline(&mut self) {
-        let registers = &self.video_registers.borrow();
+        {
+            let registers = &self.video_registers.borrow();
 
-        let snapshot_params = self.crtc.get_snapshot_params(registers);
+            let snapshot_params = self.crtc.get_snapshot_params(registers);
 
-        if snapshot_params.is_displayed {
-            self.video_field.snapshot_scanline(
-                snapshot_params.beam_scanline as usize,
-                snapshot_params.address,
-                snapshot_params.raster_address_even,
-                snapshot_params.raster_address_odd,
-                self.ic32_latch.get(),
-                self.field_counter,
-                registers,
-                |range| self.ram.slice(range),
-            );
+            if snapshot_params.is_displayed {
+                self.video_field.snapshot_scanline(
+                    snapshot_params.beam_scanline as usize,
+                    snapshot_params.address,
+                    snapshot_params.raster_address_even,
+                    snapshot_params.raster_address_odd,
+                    self.ic32_latch.get(),
+                    self.field_counter,
+                    registers,
+                    |range| self.ram.slice(range),
+                );
+            }
+
+            self.crtc.advance_scanline(registers);
         }
 
-        self.crtc.advance_scanline(registers);
+        let crtc_vsync = self.crtc.is_in_vsync();
+        if self.vsync != crtc_vsync {
+            self.vsync = crtc_vsync;
+            self.on_vsync_change(crtc_vsync);
+        }
     }
 
     pub fn reset(&mut self) {

--- a/ch22-core/src/system/core.rs
+++ b/ch22-core/src/system/core.rs
@@ -9,7 +9,9 @@ use super::{
 };
 use crate::address_spaces::{IOSpace, Ram, Rom};
 use crate::devices::{RomSelect, TimerDeviceList};
-use crate::video::{Field, VideoCRTCRegistersDevice, VideoRegisters, VideoULARegistersDevice};
+use crate::video::{
+    CRTC, Field, VideoCRTCRegistersDevice, VideoRegisters, VideoULARegistersDevice,
+};
 use crate::{cpu::Cpu, devices::DeviceSpeed};
 
 #[derive(Default)]
@@ -20,6 +22,7 @@ pub struct Core {
     pub roms: [Rom; ROMS_LEN],
     pub io_space: IOSpace,
     pub video_field: Field,
+    pub crtc: CRTC,
     pub ic32_latch: Rc<Cell<u8>>,
     pub field_counter: u8,
     pub rom_select_latch: Rc<Cell<usize>>,
@@ -30,6 +33,8 @@ pub struct Core {
 impl Core {
     pub fn setup(&mut self) {
         self.video_registers.borrow_mut().reset();
+
+        self.crtc.init(&self.video_registers.borrow());
 
         self.io_space.add_device(
             &[

--- a/ch22-core/src/system/core.rs
+++ b/ch22-core/src/system/core.rs
@@ -22,12 +22,13 @@ pub struct Core {
     pub roms: [Rom; ROMS_LEN],
     pub io_space: IOSpace,
     pub video_field: Field,
-    pub crtc: Crtc,
-    pub vsync: bool,
+    crtc: Crtc,
+    vsync: bool,
+    video_trigger: u64,
     pub ic32_latch: Rc<Cell<u8>>,
-    pub field_counter: u8,
-    pub rom_select_latch: Rc<Cell<usize>>,
-    pub video_registers: Rc<RefCell<VideoRegisters>>,
+    field_counter: u8,
+    rom_select_latch: Rc<Cell<usize>>,
+    video_registers: Rc<RefCell<VideoRegisters>>,
     pub timer_devices: TimerDeviceList,
 }
 
@@ -131,7 +132,24 @@ impl Core {
         });
     }
 
-    pub fn run(&mut self, until: u64) -> u64 {
+    pub fn run_one_field(&mut self) -> u64 {
+        loop {
+            let cycles = self.run(self.video_trigger);
+
+            self.process_scanline();
+
+            self.video_trigger += self
+                .crtc
+                .get_next_scanline_trigger(&self.video_registers.borrow())
+                as u64;
+
+            if self.crtc.is_beam_reset() {
+                return cycles;
+            }
+        }
+    }
+
+    fn run(&mut self, until: u64) -> u64 {
         self.with_runner(|runner| {
             runner.run(until);
         })

--- a/ch22-core/src/system/core.rs
+++ b/ch22-core/src/system/core.rs
@@ -86,10 +86,6 @@ impl Core {
         }
     }
 
-    pub fn inc_field_counter(&mut self) {
-        self.field_counter = self.field_counter.wrapping_add(1);
-    }
-
     pub fn on_vsync_change(&mut self, vsync: bool) {
         self.io_space.on_vsync_change(vsync);
     }
@@ -99,6 +95,12 @@ impl Core {
             let registers = &self.video_registers.borrow();
 
             let snapshot_params = self.crtc.get_snapshot_params(registers);
+
+            if snapshot_params.beam_scanline == 0 {
+                self.field_counter = self.field_counter.wrapping_add(1);
+
+                self.video_field.clear();
+            }
 
             if snapshot_params.is_displayed {
                 self.video_field.snapshot_scanline(

--- a/ch22-core/src/system/core.rs
+++ b/ch22-core/src/system/core.rs
@@ -10,7 +10,7 @@ use super::{
 use crate::address_spaces::{IOSpace, Ram, Rom};
 use crate::devices::{RomSelect, TimerDeviceList};
 use crate::video::{
-    CRTC, Field, VideoCRTCRegistersDevice, VideoRegisters, VideoULARegistersDevice,
+    Crtc, Field, VideoCRTCRegistersDevice, VideoRegisters, VideoULARegistersDevice,
 };
 use crate::{cpu::Cpu, devices::DeviceSpeed};
 
@@ -22,7 +22,7 @@ pub struct Core {
     pub roms: [Rom; ROMS_LEN],
     pub io_space: IOSpace,
     pub video_field: Field,
-    pub crtc: CRTC,
+    pub crtc: Crtc,
     pub ic32_latch: Rc<Cell<u8>>,
     pub field_counter: u8,
     pub rom_select_latch: Rc<Cell<usize>>,

--- a/ch22-core/src/system/core.rs
+++ b/ch22-core/src/system/core.rs
@@ -1,4 +1,4 @@
-use std::cell::{Cell, RefCell};
+use std::cell::Cell;
 use std::rc::Rc;
 
 use super::{
@@ -9,9 +9,7 @@ use super::{
 };
 use crate::address_spaces::{IOSpace, Ram, Rom};
 use crate::devices::{RomSelect, TimerDeviceList};
-use crate::video::{
-    Crtc, Field, VideoCRTCRegistersDevice, VideoRegisters, VideoULARegistersDevice,
-};
+use crate::video::{Video, VideoCRTCRegistersDevice, VideoULARegistersDevice};
 use crate::{cpu::Cpu, devices::DeviceSpeed};
 
 #[derive(Default)]
@@ -21,35 +19,28 @@ pub struct Core {
     ram: Ram,
     pub roms: [Rom; ROMS_LEN],
     pub io_space: IOSpace,
-    pub video_field: Field,
-    crtc: Crtc,
-    vsync: bool,
-    video_trigger: u64,
     pub ic32_latch: Rc<Cell<u8>>,
-    field_counter: u8,
     rom_select_latch: Rc<Cell<usize>>,
-    video_registers: Rc<RefCell<VideoRegisters>>,
     pub timer_devices: TimerDeviceList,
+    pub video: Video,
 }
 
 impl Core {
     pub fn setup(&mut self) {
-        self.video_registers.borrow_mut().reset();
-
-        self.crtc.init(&self.video_registers.borrow());
+        self.video.init();
 
         self.io_space.add_device(
             &[
                 0xfe00, 0xfe01, 0xfe02, 0xfe03, 0xfe04, 0xfe05, 0xfe06, 0xfe07,
             ],
-            Box::new(VideoCRTCRegistersDevice::new(self.video_registers.clone())),
+            Box::new(VideoCRTCRegistersDevice::new(self.video.registers.clone())),
             None,
             DeviceSpeed::OneMhz,
         );
 
         self.io_space.add_device(
             &[0xfe20, 0xfe21, 0xfe22, 0xfe23],
-            Box::new(VideoULARegistersDevice::new(self.video_registers.clone())),
+            Box::new(VideoULARegistersDevice::new(self.video.registers.clone())),
             None,
             DeviceSpeed::OneMhz,
         );
@@ -62,8 +53,6 @@ impl Core {
             None,
             DeviceSpeed::TwoMhz,
         );
-
-        self.field_counter = 0;
     }
 
     fn address_map() -> impl AddressMap {
@@ -87,45 +76,6 @@ impl Core {
         }
     }
 
-    pub fn on_vsync_change(&mut self, vsync: bool) {
-        self.io_space.on_vsync_change(vsync);
-    }
-
-    pub fn process_scanline(&mut self) {
-        {
-            let registers = &self.video_registers.borrow();
-
-            let snapshot_params = self.crtc.get_snapshot_params(registers);
-
-            if snapshot_params.beam_scanline == 0 {
-                self.field_counter = self.field_counter.wrapping_add(1);
-
-                self.video_field.clear();
-            }
-
-            if snapshot_params.is_displayed {
-                self.video_field.snapshot_scanline(
-                    snapshot_params.beam_scanline as usize,
-                    snapshot_params.address,
-                    snapshot_params.raster_address_even,
-                    snapshot_params.raster_address_odd,
-                    self.ic32_latch.get(),
-                    self.field_counter,
-                    registers,
-                    |range| self.ram.slice(range),
-                );
-            }
-
-            self.crtc.advance_scanline(registers);
-        }
-
-        let crtc_vsync = self.crtc.is_in_vsync();
-        if self.vsync != crtc_vsync {
-            self.vsync = crtc_vsync;
-            self.on_vsync_change(crtc_vsync);
-        }
-    }
-
     pub fn reset(&mut self) {
         self.with_runner(|runner| {
             runner.reset();
@@ -134,28 +84,27 @@ impl Core {
 
     pub fn run_one_field(&mut self) -> u64 {
         loop {
-            let cycles = self.run(self.video_trigger);
+            self.run(self.video.get_next_scanline_trigger());
 
-            self.process_scanline();
+            let is_field_complete = self.video.process_scanline(
+                self.ic32_latch.get(),
+                |range| self.ram.slice(range),
+                |vsync| self.io_space.on_vsync_change(vsync),
+            );
 
-            self.video_trigger += self
-                .crtc
-                .get_next_scanline_trigger(&self.video_registers.borrow())
-                as u64;
-
-            if self.crtc.is_beam_reset() {
-                return cycles;
+            if is_field_complete {
+                return self.cycles;
             }
         }
     }
 
-    fn run(&mut self, until: u64) -> u64 {
+    fn run(&mut self, until: u64) {
         self.with_runner(|runner| {
             runner.run(until);
         })
     }
 
-    fn with_runner(&mut self, run_fn: impl FnOnce(&mut dyn RunnerTrait)) -> u64 {
+    fn with_runner(&mut self, run_fn: impl FnOnce(&mut dyn RunnerTrait)) {
         let clock = Clock::new(&mut self.cycles, &mut self.timer_devices);
 
         let cpu_bus = CpuBus::new(
@@ -173,8 +122,6 @@ impl Core {
         };
 
         run_fn(&mut runner);
-
-        self.cycles
     }
 }
 

--- a/ch22-core/src/system/core.rs
+++ b/ch22-core/src/system/core.rs
@@ -93,23 +93,25 @@ impl Core {
         self.io_space.on_vsync_change(vsync);
     }
 
-    pub fn snapshot_scanline(
-        &mut self,
-        line_index: usize,
-        crtc_memory_address: u16,
-        crtc_raster_address_even: u8,
-        crtc_raster_address_odd: u8,
-    ) {
-        self.video_field.snapshot_scanline(
-            line_index,
-            crtc_memory_address,
-            crtc_raster_address_even,
-            crtc_raster_address_odd,
-            self.ic32_latch.get(),
-            self.field_counter,
-            &self.video_registers.borrow(),
-            |range| self.ram.slice(range),
-        );
+    pub fn process_scanline(&mut self) {
+        let registers = &self.video_registers.borrow();
+
+        let snapshot_params = self.crtc.get_snapshot_params(registers);
+
+        if snapshot_params.is_displayed {
+            self.video_field.snapshot_scanline(
+                snapshot_params.beam_scanline as usize,
+                snapshot_params.address,
+                snapshot_params.raster_address_even,
+                snapshot_params.raster_address_odd,
+                self.ic32_latch.get(),
+                self.field_counter,
+                registers,
+                |range| self.ram.slice(range),
+            );
+        }
+
+        self.crtc.advance_scanline(registers);
     }
 
     pub fn reset(&mut self) {

--- a/ch22-core/src/system/system_ffi.rs
+++ b/ch22-core/src/system/system_ffi.rs
@@ -136,23 +136,6 @@ impl SystemFfi {
             .set_device_trigger(device_id, trigger);
     }
 
-    pub fn get_partial_video_registers(&self) -> u128 {
-        let registers = self.core.video_registers.borrow();
-
-        (registers.crtc_r0_horizontal_total as u128)
-            | (registers.crtc_r1_horizontal_displayed as u128) << 8
-            | (registers.crtc_r3_sync_width as u128) << 16
-            | (registers.crtc_r4_vertical_total as u128) << 24
-            | (registers.crtc_r5_vertical_total_adjust as u128) << 32
-            | (registers.crtc_r6_vertical_displayed as u128) << 40
-            | (registers.crtc_r7_vertical_sync_position as u128) << 48
-            | (registers.crtc_r8_interlace_and_skew as u128) << 56
-            | (registers.crtc_r9_maximum_raster_address as u128) << 64
-            | (registers.crtc_r12_start_address_h as u128) << 72
-            | (registers.crtc_r13_start_address_l as u128) << 80
-            | (registers.ula_control as u128) << 88
-    }
-
     pub fn process_scanline(&mut self) -> u64 {
         self.core.process_scanline();
 

--- a/ch22-core/src/system/system_ffi.rs
+++ b/ch22-core/src/system/system_ffi.rs
@@ -37,14 +37,6 @@ impl SystemFfi {
         size_of::<Field>()
     }
 
-    pub fn video_field_clear(&mut self) {
-        self.core.video_field.clear();
-    }
-
-    pub fn inc_field_counter(&mut self) {
-        self.core.inc_field_counter();
-    }
-
     pub fn load_rom(&mut self, bank: usize, data: &[u8]) {
         if bank >= ROMS_LEN {
             panic!("Invalid ROM bank: {bank}");

--- a/ch22-core/src/system/system_ffi.rs
+++ b/ch22-core/src/system/system_ffi.rs
@@ -114,8 +114,8 @@ impl SystemFfi {
         self.core.reset();
     }
 
-    pub fn run(&mut self, until: u64) -> u64 {
-        self.core.run(until)
+    pub fn run_one_field(&mut self) -> u64 {
+        self.core.run_one_field()
     }
 
     pub fn set_device_interrupt(&mut self, device_id: IODeviceID, interrupt: bool) {
@@ -126,22 +126,6 @@ impl SystemFfi {
         self.core
             .timer_devices
             .set_device_trigger(device_id, trigger);
-    }
-
-    pub fn process_scanline(&mut self) -> u64 {
-        self.core.process_scanline();
-
-        let mut packed: u64 = 0;
-
-        let crtc = &self.core.crtc;
-
-        if crtc.is_beam_reset() {
-            packed |= 1;
-        }
-
-        packed |= (crtc.get_next_scanline_trigger(&self.core.video_registers.borrow()) as u64) << 4;
-
-        packed
     }
 }
 

--- a/ch22-core/src/system/system_ffi.rs
+++ b/ch22-core/src/system/system_ffi.rs
@@ -171,6 +171,32 @@ impl SystemFfi {
             | (registers.crtc_r13_start_address_l as u128) << 80
             | (registers.ula_control as u128) << 88
     }
+
+    pub fn advance_scanline(&mut self) -> u64 {
+        let result = self
+            .core
+            .crtc
+            .advance_scanline(&self.core.video_registers.borrow());
+
+        let mut packed: u64 = 0;
+
+        if result.field_complete {
+            packed |= 1;
+        }
+        if result.vsync {
+            packed |= 2;
+        }
+        if result.snapshot_params.in_scan {
+            packed |= 4;
+        }
+        packed |= (result.next_scanline_trigger as u64) << 4;
+        packed |= (result.snapshot_params.address as u64) << 20;
+        packed |= (result.snapshot_params.raster_address_even as u64) << 36;
+        packed |= (result.snapshot_params.raster_address_odd as u64) << 44;
+        packed |= (result.snapshot_params.scanline as u64) << 52;
+
+        packed
+    }
 }
 
 const JS_DEVICE_ONE_MHZ: u8 = 0b0000_0001;

--- a/ch22-core/src/system/system_ffi.rs
+++ b/ch22-core/src/system/system_ffi.rs
@@ -30,7 +30,7 @@ impl SystemFfi {
     }
 
     pub fn video_field_start(&mut self) -> *const Field {
-        &self.core.video_field as *const Field
+        self.core.video.get_field_start()
     }
 
     pub fn video_field_size(&self) -> usize {

--- a/ch22-core/src/system/system_ffi.rs
+++ b/ch22-core/src/system/system_ffi.rs
@@ -45,21 +45,6 @@ impl SystemFfi {
         self.core.inc_field_counter();
     }
 
-    pub fn snapshot_scanline(
-        &mut self,
-        line_index: usize,
-        crtc_memory_address: u16,
-        crtc_raster_address_even: u8,
-        crtc_raster_address_odd: u8,
-    ) {
-        self.core.snapshot_scanline(
-            line_index,
-            crtc_memory_address,
-            crtc_raster_address_even,
-            crtc_raster_address_odd,
-        );
-    }
-
     pub fn load_rom(&mut self, bank: usize, data: &[u8]) {
         if bank >= ROMS_LEN {
             panic!("Invalid ROM bank: {bank}");
@@ -173,14 +158,11 @@ impl SystemFfi {
     }
 
     pub fn process_scanline(&mut self) -> u64 {
-        let registers = &self.core.video_registers.borrow();
-        let crtc = &mut self.core.crtc;
-
-        let snapshot_params = crtc.get_snapshot_params(registers);
-
-        crtc.advance_scanline(registers);
+        self.core.process_scanline();
 
         let mut packed: u64 = 0;
+
+        let crtc = &self.core.crtc;
 
         if crtc.is_beam_reset() {
             packed |= 1;
@@ -188,14 +170,8 @@ impl SystemFfi {
         if crtc.is_in_vsync() {
             packed |= 2;
         }
-        if snapshot_params.is_displayed {
-            packed |= 4;
-        }
-        packed |= (crtc.get_next_scanline_trigger(registers) as u64) << 4;
-        packed |= (snapshot_params.address as u64) << 20;
-        packed |= (snapshot_params.raster_address_even as u64) << 36;
-        packed |= (snapshot_params.raster_address_odd as u64) << 44;
-        packed |= (snapshot_params.beam_scanline as u64) << 52;
+
+        packed |= (crtc.get_next_scanline_trigger(&self.core.video_registers.borrow()) as u64) << 4;
 
         packed
     }

--- a/ch22-core/src/system/system_ffi.rs
+++ b/ch22-core/src/system/system_ffi.rs
@@ -188,7 +188,7 @@ impl SystemFfi {
         if crtc.is_in_vsync() {
             packed |= 2;
         }
-        if snapshot_params.in_scan {
+        if snapshot_params.is_displayed {
             packed |= 4;
         }
         packed |= (crtc.get_next_scanline_trigger(registers) as u64) << 4;

--- a/ch22-core/src/system/system_ffi.rs
+++ b/ch22-core/src/system/system_ffi.rs
@@ -193,7 +193,7 @@ impl SystemFfi {
         packed |= (result.snapshot_params.address as u64) << 20;
         packed |= (result.snapshot_params.raster_address_even as u64) << 36;
         packed |= (result.snapshot_params.raster_address_odd as u64) << 44;
-        packed |= (result.snapshot_params.scanline as u64) << 52;
+        packed |= (result.snapshot_params.beam_scanline as u64) << 52;
 
         packed
     }

--- a/ch22-core/src/system/system_ffi.rs
+++ b/ch22-core/src/system/system_ffi.rs
@@ -172,7 +172,7 @@ impl SystemFfi {
             | (registers.ula_control as u128) << 88
     }
 
-    pub fn advance_scanline(&mut self) -> u64 {
+    pub fn process_scanline(&mut self) -> u64 {
         let registers = &self.core.video_registers.borrow();
         let crtc = &mut self.core.crtc;
 

--- a/ch22-core/src/system/system_ffi.rs
+++ b/ch22-core/src/system/system_ffi.rs
@@ -118,10 +118,6 @@ impl SystemFfi {
             .add_device(Box::new(JsTimerDevice::new(js_handle_trigger)))
     }
 
-    pub fn on_vsync_change(&mut self, vsync: bool) {
-        self.core.on_vsync_change(vsync);
-    }
-
     pub fn reset(&mut self) {
         self.core.reset();
     }
@@ -166,9 +162,6 @@ impl SystemFfi {
 
         if crtc.is_beam_reset() {
             packed |= 1;
-        }
-        if crtc.is_in_vsync() {
-            packed |= 2;
         }
 
         packed |= (crtc.get_next_scanline_trigger(&self.core.video_registers.borrow()) as u64) << 4;

--- a/ch22-core/src/system/system_ffi.rs
+++ b/ch22-core/src/system/system_ffi.rs
@@ -173,27 +173,29 @@ impl SystemFfi {
     }
 
     pub fn advance_scanline(&mut self) -> u64 {
-        let result = self
-            .core
-            .crtc
-            .advance_scanline(&self.core.video_registers.borrow());
+        let registers = &self.core.video_registers.borrow();
+        let crtc = &mut self.core.crtc;
+
+        let snapshot_params = crtc.get_snapshot_params(registers);
+
+        crtc.advance_scanline(registers);
 
         let mut packed: u64 = 0;
 
-        if result.field_complete {
+        if crtc.is_beam_reset() {
             packed |= 1;
         }
-        if result.vsync {
+        if crtc.is_in_vsync() {
             packed |= 2;
         }
-        if result.snapshot_params.in_scan {
+        if snapshot_params.in_scan {
             packed |= 4;
         }
-        packed |= (result.next_scanline_trigger as u64) << 4;
-        packed |= (result.snapshot_params.address as u64) << 20;
-        packed |= (result.snapshot_params.raster_address_even as u64) << 36;
-        packed |= (result.snapshot_params.raster_address_odd as u64) << 44;
-        packed |= (result.snapshot_params.beam_scanline as u64) << 52;
+        packed |= (crtc.get_next_scanline_trigger(registers) as u64) << 4;
+        packed |= (snapshot_params.address as u64) << 20;
+        packed |= (snapshot_params.raster_address_even as u64) << 36;
+        packed |= (snapshot_params.raster_address_odd as u64) << 44;
+        packed |= (snapshot_params.beam_scanline as u64) << 52;
 
         packed
     }

--- a/ch22-core/src/system/system_ffi.rs
+++ b/ch22-core/src/system/system_ffi.rs
@@ -96,6 +96,7 @@ impl SystemFfi {
         addresses: &[u16],
         js_read: Function,
         js_write: Function,
+        js_on_vsync_change: Option<Function>,
         js_handle_trigger: Function,
         flags: u8,
     ) -> IODeviceID {
@@ -116,6 +117,7 @@ impl SystemFfi {
             Box::new(JsIODevice::new(
                 js_read,
                 js_write,
+                js_on_vsync_change,
                 js_handle_trigger,
                 flags & JS_DEVICE_PHASE_2_WRITE != 0,
                 ic32_latch,
@@ -129,6 +131,10 @@ impl SystemFfi {
         self.core
             .timer_devices
             .add_device(Box::new(JsTimerDevice::new(js_handle_trigger)))
+    }
+
+    pub fn on_vsync_change(&mut self, vsync: bool) {
+        self.core.on_vsync_change(vsync);
     }
 
     pub fn reset(&mut self) {

--- a/ch22-core/src/video.rs
+++ b/ch22-core/src/video.rs
@@ -8,13 +8,85 @@ mod video_ula_registers_device;
 
 pub const MAX_LINES: usize = 320;
 
-pub use crtc::Crtc;
+use std::{cell::RefCell, rc::Rc};
+
+use crtc::Crtc;
 pub use field_data::Field;
-pub use field_line::FieldLine;
+use field_line::FieldLine;
 pub use video_crtc_registers_device::VideoCRTCRegistersDevice;
-pub use video_memory_access::VideoMemoryAccess;
+use video_memory_access::VideoMemoryAccess;
 pub use video_registers::VideoRegisters;
 pub use video_ula_registers_device::VideoULARegistersDevice;
 
 #[cfg(test)]
 pub use field_line::flags as field_line_flags;
+
+#[derive(Default)]
+pub struct Video {
+    field: Field,
+    crtc: Crtc,
+    pub registers: Rc<RefCell<VideoRegisters>>,
+    field_counter: u8,
+    next_scanline_trigger: u64,
+    vsync: bool,
+}
+
+impl Video {
+    pub fn init(&mut self) {
+        self.registers.borrow_mut().reset();
+
+        self.crtc.init(&self.registers.borrow());
+
+        self.field_counter = 0;
+    }
+
+    pub fn process_scanline<'a>(
+        &mut self,
+        ic32_latch: u8,
+        get_buffer: impl Fn(std::ops::Range<u16>) -> &'a [u8],
+        mut on_vsync_change: impl FnMut(bool),
+    ) -> bool {
+        let registers = &self.registers.borrow();
+
+        let snapshot_params = self.crtc.get_snapshot_params(registers);
+
+        if snapshot_params.beam_scanline == 0 {
+            self.field_counter = self.field_counter.wrapping_add(1);
+
+            self.field.clear();
+        }
+
+        if snapshot_params.is_displayed {
+            self.field.snapshot_scanline(
+                snapshot_params.beam_scanline as usize,
+                snapshot_params.address,
+                snapshot_params.raster_address_even,
+                snapshot_params.raster_address_odd,
+                ic32_latch,
+                self.field_counter,
+                registers,
+                get_buffer,
+            );
+        }
+
+        self.crtc.advance_scanline(registers);
+
+        self.next_scanline_trigger += self.crtc.get_next_scanline_trigger(registers) as u64;
+
+        let new_vsync = self.crtc.is_in_vsync();
+        if self.vsync != new_vsync {
+            self.vsync = new_vsync;
+            on_vsync_change(new_vsync);
+        }
+
+        self.crtc.is_beam_reset()
+    }
+
+    pub fn get_next_scanline_trigger(&self) -> u64 {
+        self.next_scanline_trigger
+    }
+
+    pub fn get_field_start(&self) -> *const Field {
+        &self.field as *const Field
+    }
+}

--- a/ch22-core/src/video.rs
+++ b/ch22-core/src/video.rs
@@ -1,3 +1,4 @@
+mod crtc;
 mod field_data;
 mod field_line;
 mod video_crtc_registers_device;
@@ -5,6 +6,10 @@ mod video_memory_access;
 mod video_registers;
 mod video_ula_registers_device;
 
+pub const MAX_LINES: usize = 320;
+
+#[allow(unused_imports)]
+pub use crtc::CRTC;
 pub use field_data::Field;
 pub use field_line::FieldLine;
 pub use video_crtc_registers_device::VideoCRTCRegistersDevice;

--- a/ch22-core/src/video.rs
+++ b/ch22-core/src/video.rs
@@ -13,19 +13,19 @@ use std::{cell::RefCell, rc::Rc};
 use crtc::Crtc;
 pub use field_data::Field;
 use field_line::FieldLine;
-pub use video_crtc_registers_device::VideoCRTCRegistersDevice;
+use video_crtc_registers_device::VideoCRTCRegistersDevice;
 use video_memory_access::VideoMemoryAccess;
-pub use video_registers::VideoRegisters;
-pub use video_ula_registers_device::VideoULARegistersDevice;
+use video_registers::VideoRegisters;
+use video_ula_registers_device::VideoULARegistersDevice;
 
 #[cfg(test)]
 pub use field_line::flags as field_line_flags;
 
 #[derive(Default)]
 pub struct Video {
-    field: Field,
+    field_data: Field,
     crtc: Crtc,
-    pub registers: Rc<RefCell<VideoRegisters>>,
+    registers: Rc<RefCell<VideoRegisters>>,
     field_counter: u8,
     next_scanline_trigger: u64,
     vsync: bool,
@@ -38,6 +38,14 @@ impl Video {
         self.crtc.init(&self.registers.borrow());
 
         self.field_counter = 0;
+    }
+
+    pub fn create_crtc_registers_device(&self) -> VideoCRTCRegistersDevice {
+        VideoCRTCRegistersDevice::new(self.registers.clone())
+    }
+
+    pub fn create_ula_registers_device(&self) -> VideoULARegistersDevice {
+        VideoULARegistersDevice::new(self.registers.clone())
     }
 
     pub fn process_scanline<'a>(
@@ -53,11 +61,11 @@ impl Video {
         if snapshot_params.beam_scanline == 0 {
             self.field_counter = self.field_counter.wrapping_add(1);
 
-            self.field.clear();
+            self.field_data.clear();
         }
 
         if snapshot_params.is_displayed {
-            self.field.snapshot_scanline(
+            self.field_data.snapshot_scanline(
                 snapshot_params.beam_scanline as usize,
                 snapshot_params.address,
                 snapshot_params.raster_address_even,
@@ -71,7 +79,7 @@ impl Video {
 
         self.crtc.advance_scanline(registers);
 
-        self.next_scanline_trigger += self.crtc.get_next_scanline_trigger(registers) as u64;
+        self.next_scanline_trigger += self.crtc.get_next_scanline_cycles(registers);
 
         let new_vsync = self.crtc.is_in_vsync();
         if self.vsync != new_vsync {
@@ -79,6 +87,7 @@ impl Video {
             on_vsync_change(new_vsync);
         }
 
+        // field is complete
         self.crtc.is_beam_reset()
     }
 
@@ -87,6 +96,6 @@ impl Video {
     }
 
     pub fn get_field_start(&self) -> *const Field {
-        &self.field as *const Field
+        &self.field_data as *const Field
     }
 }

--- a/ch22-core/src/video.rs
+++ b/ch22-core/src/video.rs
@@ -8,7 +8,7 @@ mod video_ula_registers_device;
 
 pub const MAX_LINES: usize = 320;
 
-pub use crtc::CRTC;
+pub use crtc::Crtc;
 pub use field_data::Field;
 pub use field_line::FieldLine;
 pub use video_crtc_registers_device::VideoCRTCRegistersDevice;

--- a/ch22-core/src/video.rs
+++ b/ch22-core/src/video.rs
@@ -8,7 +8,6 @@ mod video_ula_registers_device;
 
 pub const MAX_LINES: usize = 320;
 
-#[allow(unused_imports)]
 pub use crtc::CRTC;
 pub use field_data::Field;
 pub use field_line::FieldLine;

--- a/ch22-core/src/video/crtc.rs
+++ b/ch22-core/src/video/crtc.rs
@@ -1,15 +1,12 @@
 #![allow(dead_code)]
 
-use std::cell::RefCell;
-use std::rc::Rc;
-
 use crate::video::{MAX_LINES, VideoRegisters};
 
 #[cfg(test)]
 mod tests;
 
+#[derive(Default)]
 pub struct CRTC {
-    registers: Rc<RefCell<VideoRegisters>>,
     addr: u16,
     char_line: u16,
     in_char_line_up: u16,
@@ -18,7 +15,6 @@ pub struct CRTC {
     scanline: u16,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct SnapshotParams {
     pub in_scan: bool,
     pub scanline: u16,
@@ -27,7 +23,6 @@ pub struct SnapshotParams {
     pub raster_address_odd: u8,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct AdvanceScanlineResult {
     pub field_complete: bool,
     pub next_scanline_trigger: u16,
@@ -36,21 +31,7 @@ pub struct AdvanceScanlineResult {
 }
 
 impl CRTC {
-    pub fn new(registers: Rc<RefCell<VideoRegisters>>) -> Self {
-        CRTC {
-            registers,
-            addr: 0,
-            char_line: 0,
-            in_char_line_up: 0,
-            vsync_state: 0,
-            interlace_frame: false,
-            scanline: 0,
-        }
-    }
-
-    pub fn init(&mut self) {
-        let registers = *self.registers.borrow();
-
+    pub fn init(&mut self, registers: &VideoRegisters) {
         self.char_line = 0;
         self.in_char_line_up = 0;
         self.vsync_state = 0;
@@ -62,8 +43,7 @@ impl CRTC {
         );
     }
 
-    pub fn advance_scanline(&mut self) -> AdvanceScanlineResult {
-        let registers = *self.registers.borrow();
+    pub fn advance_scanline(&mut self, registers: &VideoRegisters) -> AdvanceScanlineResult {
         let sync_and_video = registers.r8_is_interlace_sync_and_video();
 
         let raster_base = self.in_char_line_up * if sync_and_video { 2 } else { 1 };

--- a/ch22-core/src/video/crtc.rs
+++ b/ch22-core/src/video/crtc.rs
@@ -84,8 +84,8 @@ impl Crtc {
         }
     }
 
-    pub fn get_next_scanline_trigger(&self, registers: &VideoRegisters) -> u16 {
-        let mut next_scanline_trigger = registers.crtc_r0_horizontal_total as u16 + 1;
+    pub fn get_next_scanline_cycles(&self, registers: &VideoRegisters) -> u64 {
+        let mut next_scanline_trigger = registers.crtc_r0_horizontal_total as u64 + 1;
 
         if !registers.ula_is_high_frequency() {
             next_scanline_trigger *= 2;

--- a/ch22-core/src/video/crtc.rs
+++ b/ch22-core/src/video/crtc.rs
@@ -16,7 +16,7 @@ use self::vsync_control::VSyncControl;
 mod tests;
 
 pub struct SnapshotParams {
-    pub in_scan: bool,
+    pub is_displayed: bool,
     pub beam_scanline: u16,
     pub address: u16,
     pub raster_address_even: u8,
@@ -76,7 +76,7 @@ impl Crtc {
 
     pub fn get_snapshot_params(&self, registers: &VideoRegisters) -> SnapshotParams {
         SnapshotParams {
-            in_scan: self.char_raster_control.is_in_scan(registers),
+            is_displayed: self.char_raster_control.is_displayed(registers),
             beam_scanline: self.beam_control.get_scanline(),
             address: self.address_control.get_address(),
             raster_address_even: self.char_raster_control.get_raster_address_even(registers),

--- a/ch22-core/src/video/crtc.rs
+++ b/ch22-core/src/video/crtc.rs
@@ -1,19 +1,19 @@
 #![allow(dead_code)]
 
-use crate::video::{MAX_LINES, VideoRegisters};
+use crate::video::VideoRegisters;
+
+mod address_control;
+mod beam_control;
+mod char_row;
+mod vsync_control;
+
+use self::address_control::AddressControl;
+use self::beam_control::BeamControl;
+use self::char_row::{CharRowControl, CharRowPosition};
+use self::vsync_control::VSyncControl;
 
 #[cfg(test)]
 mod tests;
-
-#[derive(Default)]
-pub struct CRTC {
-    address: u16,
-    char_row_counter: u8,
-    char_raster_counter: u8,
-    vsync_line_counter: u8,
-    odd_field: bool,
-    beam_scanline: u16,
-}
 
 pub struct SnapshotParams {
     pub in_scan: bool,
@@ -30,98 +30,79 @@ pub struct AdvanceScanlineResult {
     pub vsync: bool,
 }
 
+#[derive(Default)]
+pub struct CRTC {
+    char_row_control: CharRowControl,
+    address_control: AddressControl,
+    vsync_control: VSyncControl,
+    beam_control: BeamControl,
+    odd_field: bool,
+}
+
 impl CRTC {
     pub fn init(&mut self, registers: &VideoRegisters) {
-        self.char_row_counter = 0;
-        self.char_raster_counter = 0;
-        self.vsync_line_counter = 0;
+        self.char_row_control.reset();
+        self.address_control.reset(registers);
+        self.beam_control.reset();
+        self.vsync_control.reset();
         self.odd_field = false;
-        self.beam_scanline = 0;
-        self.address = registers.r12_r13_screen_address();
     }
 
     pub fn advance_scanline(&mut self, registers: &VideoRegisters) -> AdvanceScanlineResult {
         let snapshot_params = self.get_snapshot_params(registers);
 
-        debug_assert!(registers.crtc_r4_vertical_total <= 0x7F); // r4 should only be 7 bit
-        debug_assert!(registers.crtc_r5_vertical_total_adjust <= 0x1F); // r5 should only be 5 bit
+        self.beam_control.advance_scanline();
 
-        let rasters_per_char = registers.r8_r9_rasters_per_char();
+        self.vsync_control.advance_scanline();
 
-        self.beam_scanline += 1;
+        self.char_row_control.advance_scanline(registers);
 
-        if self.vsync_line_counter == 0
-            && self.char_row_counter == registers.crtc_r7_vertical_sync_position
-            && self.char_raster_counter == 0
-        {
-            self.vsync_line_counter = registers.r3_v_sync_width();
-            self.beam_scanline = 0;
-        } else if self.vsync_line_counter > 0 {
-            self.vsync_line_counter -= 1;
-        }
-
-        if self.beam_scanline == MAX_LINES as u16 {
-            self.beam_scanline = 0;
-        }
-
-        self.char_raster_counter += 1;
-
-        if self.char_row_counter <= registers.crtc_r4_vertical_total
-            && self.char_raster_counter >= rasters_per_char
-        {
-            self.char_row_counter += 1;
-            self.char_raster_counter = 0;
-            self.address = (self.address + registers.crtc_r1_horizontal_displayed as u16) & 0x3FFF;
-        }
-
-        if self.char_row_counter > registers.crtc_r4_vertical_total
-            && self.char_raster_counter >= registers.crtc_r5_vertical_total_adjust
-        {
-            // start new field
-            self.odd_field = !self.odd_field;
-            self.char_row_counter = 0;
-            self.char_raster_counter = 0;
-            self.address = registers.r12_r13_screen_address();
+        if let Some(position) = self.char_row_control.get_position(registers) {
+            match position {
+                CharRowPosition::StartOfField => {
+                    self.address_control.reset(registers);
+                    self.odd_field = !self.odd_field;
+                }
+                CharRowPosition::StartOfCharRow => {
+                    self.address_control.advance_char_row(registers);
+                }
+                CharRowPosition::VsyncStart => {
+                    if self.vsync_control.start_vsync_period(registers) {
+                        self.beam_control.reset();
+                    }
+                }
+            }
         }
 
         AdvanceScanlineResult {
-            field_complete: self.beam_scanline == 0,
+            field_complete: self.beam_control.get_scanline() == 0,
             next_scanline_trigger: self.get_next_scanline_trigger(registers),
             snapshot_params,
-            vsync: self.vsync_line_counter > 0,
+            vsync: self.vsync_control.is_in_vsync(),
         }
     }
 
     fn get_snapshot_params(&self, registers: &VideoRegisters) -> SnapshotParams {
-        let sync_and_video = registers.r8_is_interlace_sync_and_video();
-
-        let (raster_address_even, raster_address_odd) = if sync_and_video {
-            (
-                self.char_raster_counter << 1,
-                (self.char_raster_counter << 1) + 1,
-            )
-        } else {
-            (self.char_raster_counter, self.char_raster_counter)
-        };
-
         SnapshotParams {
-            in_scan: self.char_row_counter < registers.crtc_r6_vertical_displayed,
-            beam_scanline: self.beam_scanline,
-            address: self.address,
-            raster_address_even,
-            raster_address_odd,
+            in_scan: self.char_row_control.is_in_scan(registers),
+            beam_scanline: self.beam_control.get_scanline(),
+            address: self.address_control.get_address(),
+            raster_address_even: self.char_row_control.get_raster_address_even(registers),
+            raster_address_odd: self.char_row_control.get_raster_address_odd(registers),
         }
     }
 
     fn get_next_scanline_trigger(&self, registers: &VideoRegisters) -> u16 {
         let mut next_scanline_trigger = registers.crtc_r0_horizontal_total as u16 + 1;
 
-        if !registers.ula_is_high_frequency() {
+        if registers.ula_is_high_frequency() == false {
             next_scanline_trigger *= 2;
         }
 
-        if self.char_row_counter == 0
-            && self.char_raster_counter == 0
+        // in interlace mode, each field is offset by half a raster
+        // so a delay for the two halves is inserted every other field
+        // (this is an approximation)
+        if self.char_row_control.is_start_of_field()
             && self.odd_field
             && registers.r8_is_interlace()
         {

--- a/ch22-core/src/video/crtc.rs
+++ b/ch22-core/src/video/crtc.rs
@@ -1,0 +1,174 @@
+#![allow(dead_code)]
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use crate::video::{MAX_LINES, VideoRegisters};
+
+#[cfg(test)]
+mod tests;
+
+pub struct CRTC {
+    registers: Rc<RefCell<VideoRegisters>>,
+    addr: u16,
+    char_line: u16,
+    in_char_line_up: u16,
+    vsync_state: u8,
+    interlace_frame: bool,
+    scanline: u16,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SnapshotParams {
+    pub in_scan: bool,
+    pub scanline: u16,
+    pub address: u16,
+    pub raster_address_even: u8,
+    pub raster_address_odd: u8,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct AdvanceScanlineResult {
+    pub field_complete: bool,
+    pub next_scanline_trigger: u16,
+    pub snapshot_params: SnapshotParams,
+    pub vsync: bool,
+}
+
+impl CRTC {
+    pub fn new(registers: Rc<RefCell<VideoRegisters>>) -> Self {
+        CRTC {
+            registers,
+            addr: 0,
+            char_line: 0,
+            in_char_line_up: 0,
+            vsync_state: 0,
+            interlace_frame: false,
+            scanline: 0,
+        }
+    }
+
+    pub fn init(&mut self) {
+        let registers = *self.registers.borrow();
+
+        self.char_line = 0;
+        self.in_char_line_up = 0;
+        self.vsync_state = 0;
+        self.interlace_frame = false;
+        self.scanline = 0;
+        self.addr = calc_screen_address(
+            registers.crtc_r12_start_address_h,
+            registers.crtc_r13_start_address_l,
+        );
+    }
+
+    pub fn advance_scanline(&mut self) -> AdvanceScanlineResult {
+        let registers = *self.registers.borrow();
+        let sync_and_video = registers.r8_is_interlace_sync_and_video();
+
+        let raster_base = self.in_char_line_up * if sync_and_video { 2 } else { 1 };
+        let raster_odd_offset = if sync_and_video { 1 } else { 0 };
+
+        let snapshot_params = SnapshotParams {
+            in_scan: self.char_line < registers.crtc_r6_vertical_displayed as u16,
+            scanline: self.scanline,
+            address: self.addr,
+            raster_address_even: raster_base as u8,
+            raster_address_odd: (raster_base + raster_odd_offset) as u8,
+        };
+
+        let mut field_complete = false;
+
+        let char_scanlines = calc_char_scanlines(
+            registers.crtc_r9_maximum_raster_address,
+            registers.crtc_r8_interlace_and_skew,
+        );
+
+        if self.vsync_state == 0
+            && self.char_line == registers.crtc_r7_vertical_sync_position as u16
+            && self.in_char_line_up == 0
+        {
+            self.vsync_state = registers.crtc_r3_sync_width >> 4;
+            field_complete = true;
+        } else if self.vsync_state > 0 {
+            self.vsync_state -= 1;
+        }
+
+        let vsync = self.vsync_state > 0;
+
+        self.in_char_line_up += 1;
+        self.scanline += 1;
+
+        if self.char_line <= registers.crtc_r4_vertical_total as u16
+            && self.in_char_line_up >= char_scanlines
+        {
+            self.char_line += 1;
+            self.in_char_line_up = 0;
+            self.addr = self
+                .addr
+                .wrapping_add(registers.crtc_r1_horizontal_displayed as u16);
+        }
+
+        let mut next_scanline_trigger = (registers.crtc_r0_horizontal_total as u16 + 1)
+            * if calc_is_high_freq(registers.ula_control) {
+                1
+            } else {
+                2
+            };
+
+        if self.char_line > registers.crtc_r4_vertical_total as u16
+            && self.in_char_line_up >= registers.crtc_r5_vertical_total_adjust as u16
+        {
+            self.start_of_frame_data(
+                registers.crtc_r12_start_address_h,
+                registers.crtc_r13_start_address_l,
+            );
+
+            if self.interlace_frame && calc_is_interlace(registers.crtc_r8_interlace_and_skew) {
+                next_scanline_trigger = next_scanline_trigger.saturating_mul(2);
+            }
+        }
+
+        if self.scanline == MAX_LINES as u16 {
+            field_complete = true;
+        }
+
+        if field_complete {
+            self.scanline = 0;
+        }
+
+        AdvanceScanlineResult {
+            field_complete,
+            next_scanline_trigger,
+            snapshot_params,
+            vsync,
+        }
+    }
+
+    fn start_of_frame_data(&mut self, start_address_h: u8, start_address_l: u8) {
+        self.interlace_frame = !self.interlace_frame;
+        self.char_line = 0;
+        self.in_char_line_up = 0;
+        self.addr = calc_screen_address(start_address_h, start_address_l);
+    }
+}
+
+fn calc_screen_address(high: u8, low: u8) -> u16 {
+    (high as u16) << 8 | low as u16
+}
+
+fn calc_is_interlace(r8_interlace_and_skew: u8) -> bool {
+    r8_interlace_and_skew & 0x01 == 0x01
+}
+
+fn calc_is_high_freq(ula_control: u8) -> bool {
+    ula_control & 0x10 != 0
+}
+
+fn calc_char_scanlines(r9_scan_lines_per_char: u8, r8_interlace_and_skew: u8) -> u16 {
+    if r8_interlace_and_skew & 0x03 == 0x03 {
+        ((r9_scan_lines_per_char >> 1) + 1) as u16
+    } else {
+        (r9_scan_lines_per_char + 1) as u16
+    }
+}

--- a/ch22-core/src/video/crtc.rs
+++ b/ch22-core/src/video/crtc.rs
@@ -7,11 +7,11 @@ mod tests;
 
 #[derive(Default)]
 pub struct CRTC {
-    addr: u16,
-    char_line: u16,
-    in_char_line_up: u16,
-    vsync_state: u8,
-    interlace_frame: bool,
+    address: u16,
+    char_row: u8,
+    char_raster: u8,
+    vsync_line_counter: u8,
+    odd_field: bool,
     scanline: u16,
 }
 
@@ -32,123 +32,106 @@ pub struct AdvanceScanlineResult {
 
 impl CRTC {
     pub fn init(&mut self, registers: &VideoRegisters) {
-        self.char_line = 0;
-        self.in_char_line_up = 0;
-        self.vsync_state = 0;
-        self.interlace_frame = false;
+        self.char_row = 0;
+        self.char_raster = 0;
+        self.vsync_line_counter = 0;
+        self.odd_field = false;
         self.scanline = 0;
-        self.addr = calc_screen_address(
-            registers.crtc_r12_start_address_h,
-            registers.crtc_r13_start_address_l,
-        );
+        self.address = registers.r12_r13_screen_address();
     }
 
     pub fn advance_scanline(&mut self, registers: &VideoRegisters) -> AdvanceScanlineResult {
-        let sync_and_video = registers.r8_is_interlace_sync_and_video();
+        debug_assert!(registers.crtc_r4_vertical_total <= 0x7F); // r4 should only be 7 bit
+        debug_assert!(registers.crtc_r5_vertical_total_adjust <= 0x1F); // r5 should only be 5 bit
 
-        let raster_base = self.in_char_line_up * if sync_and_video { 2 } else { 1 };
-        let raster_odd_offset = if sync_and_video { 1 } else { 0 };
+        let snapshot_params = self.get_snapshot_params(registers);
 
-        let snapshot_params = SnapshotParams {
-            in_scan: self.char_line < registers.crtc_r6_vertical_displayed as u16,
-            scanline: self.scanline,
-            address: self.addr,
-            raster_address_even: raster_base as u8,
-            raster_address_odd: (raster_base + raster_odd_offset) as u8,
-        };
+        let max_char_rasters = calc_max_char_rasters(registers);
 
-        let mut field_complete = false;
-
-        let char_scanlines = calc_char_scanlines(
-            registers.crtc_r9_maximum_raster_address,
-            registers.crtc_r8_interlace_and_skew,
-        );
-
-        if self.vsync_state == 0
-            && self.char_line == registers.crtc_r7_vertical_sync_position as u16
-            && self.in_char_line_up == 0
-        {
-            self.vsync_state = registers.crtc_r3_sync_width >> 4;
-            field_complete = true;
-        } else if self.vsync_state > 0 {
-            self.vsync_state -= 1;
-        }
-
-        let vsync = self.vsync_state > 0;
-
-        self.in_char_line_up += 1;
         self.scanline += 1;
 
-        if self.char_line <= registers.crtc_r4_vertical_total as u16
-            && self.in_char_line_up >= char_scanlines
+        if self.vsync_line_counter == 0
+            && self.char_row == registers.crtc_r7_vertical_sync_position
+            && self.char_raster == 0
         {
-            self.char_line += 1;
-            self.in_char_line_up = 0;
-            self.addr = self
-                .addr
-                .wrapping_add(registers.crtc_r1_horizontal_displayed as u16);
-        }
-
-        let mut next_scanline_trigger = (registers.crtc_r0_horizontal_total as u16 + 1)
-            * if calc_is_high_freq(registers.ula_control) {
-                1
-            } else {
-                2
-            };
-
-        if self.char_line > registers.crtc_r4_vertical_total as u16
-            && self.in_char_line_up >= registers.crtc_r5_vertical_total_adjust as u16
-        {
-            self.start_of_frame_data(
-                registers.crtc_r12_start_address_h,
-                registers.crtc_r13_start_address_l,
-            );
-
-            if self.interlace_frame && calc_is_interlace(registers.crtc_r8_interlace_and_skew) {
-                next_scanline_trigger = next_scanline_trigger.saturating_mul(2);
-            }
+            self.vsync_line_counter = registers.r3_v_sync_width();
+            self.scanline = 0;
+        } else if self.vsync_line_counter > 0 {
+            self.vsync_line_counter -= 1;
         }
 
         if self.scanline == MAX_LINES as u16 {
-            field_complete = true;
-        }
-
-        if field_complete {
             self.scanline = 0;
         }
 
+        self.char_raster += 1;
+
+        if self.char_row <= registers.crtc_r4_vertical_total && self.char_raster >= max_char_rasters
+        {
+            self.char_row += 1;
+            self.char_raster = 0;
+            self.address = (self.address + registers.crtc_r1_horizontal_displayed as u16) & 0x3FFF;
+        }
+
+        if self.char_row > registers.crtc_r4_vertical_total
+            && self.char_raster >= registers.crtc_r5_vertical_total_adjust
+        {
+            // start new field
+            self.odd_field = !self.odd_field;
+            self.char_row = 0;
+            self.char_raster = 0;
+            self.address = registers.r12_r13_screen_address();
+        }
+
         AdvanceScanlineResult {
-            field_complete,
-            next_scanline_trigger,
+            field_complete: self.scanline == 0,
+            next_scanline_trigger: self.get_next_scanline_trigger(registers),
             snapshot_params,
-            vsync,
+            vsync: self.vsync_line_counter > 0,
         }
     }
 
-    fn start_of_frame_data(&mut self, start_address_h: u8, start_address_l: u8) {
-        self.interlace_frame = !self.interlace_frame;
-        self.char_line = 0;
-        self.in_char_line_up = 0;
-        self.addr = calc_screen_address(start_address_h, start_address_l);
+    fn get_snapshot_params(&self, registers: &VideoRegisters) -> SnapshotParams {
+        let sync_and_video = registers.r8_is_interlace_sync_and_video();
+
+        let raster_address_even = self.char_raster << if sync_and_video { 1 } else { 0 };
+        let raster_address_odd = raster_address_even + if sync_and_video { 1 } else { 0 };
+
+        SnapshotParams {
+            in_scan: self.char_row < registers.crtc_r6_vertical_displayed,
+            scanline: self.scanline,
+            address: self.address,
+            raster_address_even,
+            raster_address_odd,
+        }
+    }
+
+    fn get_next_scanline_trigger(&self, registers: &VideoRegisters) -> u16 {
+        let mut next_scanline_trigger = registers.crtc_r0_horizontal_total as u16 + 1;
+
+        if !registers.ula_is_high_frequency() {
+            next_scanline_trigger *= 2;
+        }
+
+        if self.char_row == 0
+            && self.char_raster == 0
+            && self.odd_field
+            && registers.r8_is_interlace()
+        {
+            next_scanline_trigger *= 2;
+        }
+
+        next_scanline_trigger
     }
 }
 
-fn calc_screen_address(high: u8, low: u8) -> u16 {
-    (high as u16) << 8 | low as u16
-}
+fn calc_max_char_rasters(registers: &VideoRegisters) -> u8 {
+    // r9 should only be 5 bit
+    debug_assert!(registers.crtc_r9_maximum_raster_address <= 0x1F);
 
-fn calc_is_interlace(r8_interlace_and_skew: u8) -> bool {
-    r8_interlace_and_skew & 0x01 == 0x01
-}
-
-fn calc_is_high_freq(ula_control: u8) -> bool {
-    ula_control & 0x10 != 0
-}
-
-fn calc_char_scanlines(r9_scan_lines_per_char: u8, r8_interlace_and_skew: u8) -> u16 {
-    if r8_interlace_and_skew & 0x03 == 0x03 {
-        ((r9_scan_lines_per_char >> 1) + 1) as u16
+    if registers.r8_is_interlace_sync_and_video() {
+        (registers.crtc_r9_maximum_raster_address >> 1) + 1
     } else {
-        (r9_scan_lines_per_char + 1) as u16
+        registers.crtc_r9_maximum_raster_address + 1
     }
 }

--- a/ch22-core/src/video/crtc.rs
+++ b/ch22-core/src/video/crtc.rs
@@ -4,12 +4,12 @@ use crate::video::VideoRegisters;
 
 mod address_control;
 mod beam_control;
-mod char_row;
+mod char_raster_control;
 mod vsync_control;
 
 use self::address_control::AddressControl;
 use self::beam_control::BeamControl;
-use self::char_row::{CharRowControl, CharRowPosition};
+use self::char_raster_control::{CharRasterControl, CharRasterPosition};
 use self::vsync_control::VSyncControl;
 
 #[cfg(test)]
@@ -25,7 +25,7 @@ pub struct SnapshotParams {
 
 #[derive(Default)]
 pub struct Crtc {
-    char_row_control: CharRowControl,
+    char_raster_control: CharRasterControl,
     address_control: AddressControl,
     vsync_control: VSyncControl,
     beam_control: BeamControl,
@@ -34,7 +34,7 @@ pub struct Crtc {
 
 impl Crtc {
     pub fn init(&mut self, registers: &VideoRegisters) {
-        self.char_row_control.reset();
+        self.char_raster_control.reset();
         self.address_control.reset(registers);
         self.beam_control.reset();
         self.vsync_control.reset();
@@ -46,18 +46,18 @@ impl Crtc {
 
         self.vsync_control.advance_scanline();
 
-        self.char_row_control.advance_scanline(registers);
+        self.char_raster_control.advance_scanline(registers);
 
-        if let Some(position) = self.char_row_control.get_position(registers) {
+        if let Some(position) = self.char_raster_control.get_position(registers) {
             match position {
-                CharRowPosition::StartOfField => {
+                CharRasterPosition::StartOfField => {
                     self.address_control.reset(registers);
                     self.odd_field = !self.odd_field;
                 }
-                CharRowPosition::StartOfCharRow => {
+                CharRasterPosition::StartOfCharRow => {
                     self.address_control.advance_char_row(registers);
                 }
-                CharRowPosition::VsyncStart => {
+                CharRasterPosition::VsyncStart => {
                     if self.vsync_control.start_vsync_period(registers) {
                         self.beam_control.reset();
                     }
@@ -76,11 +76,11 @@ impl Crtc {
 
     pub fn get_snapshot_params(&self, registers: &VideoRegisters) -> SnapshotParams {
         SnapshotParams {
-            in_scan: self.char_row_control.is_in_scan(registers),
+            in_scan: self.char_raster_control.is_in_scan(registers),
             beam_scanline: self.beam_control.get_scanline(),
             address: self.address_control.get_address(),
-            raster_address_even: self.char_row_control.get_raster_address_even(registers),
-            raster_address_odd: self.char_row_control.get_raster_address_odd(registers),
+            raster_address_even: self.char_raster_control.get_raster_address_even(registers),
+            raster_address_odd: self.char_raster_control.get_raster_address_odd(registers),
         }
     }
 
@@ -94,7 +94,7 @@ impl Crtc {
         // in interlace mode, each field is offset by half a raster
         // so a delay for the two halves is inserted every other field
         // (this is an approximation)
-        if self.char_row_control.is_at_start() && self.odd_field && registers.r8_is_interlace() {
+        if self.char_raster_control.is_at_start() && self.odd_field && registers.r8_is_interlace() {
             next_scanline_trigger *= 2;
         }
 

--- a/ch22-core/src/video/crtc.rs
+++ b/ch22-core/src/video/crtc.rs
@@ -23,13 +23,6 @@ pub struct SnapshotParams {
     pub raster_address_odd: u8,
 }
 
-pub struct AdvanceScanlineResult {
-    pub field_complete: bool,
-    pub next_scanline_trigger: u16,
-    pub snapshot_params: SnapshotParams,
-    pub vsync: bool,
-}
-
 #[derive(Default)]
 pub struct Crtc {
     char_row_control: CharRowControl,
@@ -48,9 +41,7 @@ impl Crtc {
         self.odd_field = false;
     }
 
-    pub fn advance_scanline(&mut self, registers: &VideoRegisters) -> AdvanceScanlineResult {
-        let snapshot_params = self.get_snapshot_params(registers);
-
+    pub fn advance_scanline(&mut self, registers: &VideoRegisters) {
         self.beam_control.advance_scanline();
 
         self.vsync_control.advance_scanline();
@@ -73,16 +64,17 @@ impl Crtc {
                 }
             }
         }
-
-        AdvanceScanlineResult {
-            field_complete: self.beam_control.get_scanline() == 0,
-            next_scanline_trigger: self.get_next_scanline_trigger(registers),
-            snapshot_params,
-            vsync: self.vsync_control.is_in_vsync(),
-        }
     }
 
-    fn get_snapshot_params(&self, registers: &VideoRegisters) -> SnapshotParams {
+    pub fn is_beam_reset(&self) -> bool {
+        self.beam_control.get_scanline() == 0
+    }
+
+    pub fn is_in_vsync(&self) -> bool {
+        self.vsync_control.is_in_vsync()
+    }
+
+    pub fn get_snapshot_params(&self, registers: &VideoRegisters) -> SnapshotParams {
         SnapshotParams {
             in_scan: self.char_row_control.is_in_scan(registers),
             beam_scanline: self.beam_control.get_scanline(),
@@ -92,7 +84,7 @@ impl Crtc {
         }
     }
 
-    fn get_next_scanline_trigger(&self, registers: &VideoRegisters) -> u16 {
+    pub fn get_next_scanline_trigger(&self, registers: &VideoRegisters) -> u16 {
         let mut next_scanline_trigger = registers.crtc_r0_horizontal_total as u16 + 1;
 
         if !registers.ula_is_high_frequency() {
@@ -102,10 +94,7 @@ impl Crtc {
         // in interlace mode, each field is offset by half a raster
         // so a delay for the two halves is inserted every other field
         // (this is an approximation)
-        if self.char_row_control.is_start_of_field()
-            && self.odd_field
-            && registers.r8_is_interlace()
-        {
+        if self.char_row_control.is_at_start() && self.odd_field && registers.r8_is_interlace() {
             next_scanline_trigger *= 2;
         }
 

--- a/ch22-core/src/video/crtc.rs
+++ b/ch22-core/src/video/crtc.rs
@@ -31,7 +31,7 @@ pub struct AdvanceScanlineResult {
 }
 
 #[derive(Default)]
-pub struct CRTC {
+pub struct Crtc {
     char_row_control: CharRowControl,
     address_control: AddressControl,
     vsync_control: VSyncControl,
@@ -39,7 +39,7 @@ pub struct CRTC {
     odd_field: bool,
 }
 
-impl CRTC {
+impl Crtc {
     pub fn init(&mut self, registers: &VideoRegisters) {
         self.char_row_control.reset();
         self.address_control.reset(registers);
@@ -95,7 +95,7 @@ impl CRTC {
     fn get_next_scanline_trigger(&self, registers: &VideoRegisters) -> u16 {
         let mut next_scanline_trigger = registers.crtc_r0_horizontal_total as u16 + 1;
 
-        if registers.ula_is_high_frequency() == false {
+        if !registers.ula_is_high_frequency() {
             next_scanline_trigger *= 2;
         }
 

--- a/ch22-core/src/video/crtc.rs
+++ b/ch22-core/src/video/crtc.rs
@@ -8,16 +8,16 @@ mod tests;
 #[derive(Default)]
 pub struct CRTC {
     address: u16,
-    char_row: u8,
-    char_raster: u8,
+    char_row_counter: u8,
+    char_raster_counter: u8,
     vsync_line_counter: u8,
     odd_field: bool,
-    scanline: u16,
+    beam_scanline: u16,
 }
 
 pub struct SnapshotParams {
     pub in_scan: bool,
-    pub scanline: u16,
+    pub beam_scanline: u16,
     pub address: u16,
     pub raster_address_even: u8,
     pub raster_address_odd: u8,
@@ -32,59 +32,60 @@ pub struct AdvanceScanlineResult {
 
 impl CRTC {
     pub fn init(&mut self, registers: &VideoRegisters) {
-        self.char_row = 0;
-        self.char_raster = 0;
+        self.char_row_counter = 0;
+        self.char_raster_counter = 0;
         self.vsync_line_counter = 0;
         self.odd_field = false;
-        self.scanline = 0;
+        self.beam_scanline = 0;
         self.address = registers.r12_r13_screen_address();
     }
 
     pub fn advance_scanline(&mut self, registers: &VideoRegisters) -> AdvanceScanlineResult {
+        let snapshot_params = self.get_snapshot_params(registers);
+
         debug_assert!(registers.crtc_r4_vertical_total <= 0x7F); // r4 should only be 7 bit
         debug_assert!(registers.crtc_r5_vertical_total_adjust <= 0x1F); // r5 should only be 5 bit
 
-        let snapshot_params = self.get_snapshot_params(registers);
+        let rasters_per_char = registers.r8_r9_rasters_per_char();
 
-        let max_char_rasters = calc_max_char_rasters(registers);
-
-        self.scanline += 1;
+        self.beam_scanline += 1;
 
         if self.vsync_line_counter == 0
-            && self.char_row == registers.crtc_r7_vertical_sync_position
-            && self.char_raster == 0
+            && self.char_row_counter == registers.crtc_r7_vertical_sync_position
+            && self.char_raster_counter == 0
         {
             self.vsync_line_counter = registers.r3_v_sync_width();
-            self.scanline = 0;
+            self.beam_scanline = 0;
         } else if self.vsync_line_counter > 0 {
             self.vsync_line_counter -= 1;
         }
 
-        if self.scanline == MAX_LINES as u16 {
-            self.scanline = 0;
+        if self.beam_scanline == MAX_LINES as u16 {
+            self.beam_scanline = 0;
         }
 
-        self.char_raster += 1;
+        self.char_raster_counter += 1;
 
-        if self.char_row <= registers.crtc_r4_vertical_total && self.char_raster >= max_char_rasters
+        if self.char_row_counter <= registers.crtc_r4_vertical_total
+            && self.char_raster_counter >= rasters_per_char
         {
-            self.char_row += 1;
-            self.char_raster = 0;
+            self.char_row_counter += 1;
+            self.char_raster_counter = 0;
             self.address = (self.address + registers.crtc_r1_horizontal_displayed as u16) & 0x3FFF;
         }
 
-        if self.char_row > registers.crtc_r4_vertical_total
-            && self.char_raster >= registers.crtc_r5_vertical_total_adjust
+        if self.char_row_counter > registers.crtc_r4_vertical_total
+            && self.char_raster_counter >= registers.crtc_r5_vertical_total_adjust
         {
             // start new field
             self.odd_field = !self.odd_field;
-            self.char_row = 0;
-            self.char_raster = 0;
+            self.char_row_counter = 0;
+            self.char_raster_counter = 0;
             self.address = registers.r12_r13_screen_address();
         }
 
         AdvanceScanlineResult {
-            field_complete: self.scanline == 0,
+            field_complete: self.beam_scanline == 0,
             next_scanline_trigger: self.get_next_scanline_trigger(registers),
             snapshot_params,
             vsync: self.vsync_line_counter > 0,
@@ -94,12 +95,18 @@ impl CRTC {
     fn get_snapshot_params(&self, registers: &VideoRegisters) -> SnapshotParams {
         let sync_and_video = registers.r8_is_interlace_sync_and_video();
 
-        let raster_address_even = self.char_raster << if sync_and_video { 1 } else { 0 };
-        let raster_address_odd = raster_address_even + if sync_and_video { 1 } else { 0 };
+        let (raster_address_even, raster_address_odd) = if sync_and_video {
+            (
+                self.char_raster_counter << 1,
+                (self.char_raster_counter << 1) + 1,
+            )
+        } else {
+            (self.char_raster_counter, self.char_raster_counter)
+        };
 
         SnapshotParams {
-            in_scan: self.char_row < registers.crtc_r6_vertical_displayed,
-            scanline: self.scanline,
+            in_scan: self.char_row_counter < registers.crtc_r6_vertical_displayed,
+            beam_scanline: self.beam_scanline,
             address: self.address,
             raster_address_even,
             raster_address_odd,
@@ -113,8 +120,8 @@ impl CRTC {
             next_scanline_trigger *= 2;
         }
 
-        if self.char_row == 0
-            && self.char_raster == 0
+        if self.char_row_counter == 0
+            && self.char_raster_counter == 0
             && self.odd_field
             && registers.r8_is_interlace()
         {
@@ -122,16 +129,5 @@ impl CRTC {
         }
 
         next_scanline_trigger
-    }
-}
-
-fn calc_max_char_rasters(registers: &VideoRegisters) -> u8 {
-    // r9 should only be 5 bit
-    debug_assert!(registers.crtc_r9_maximum_raster_address <= 0x1F);
-
-    if registers.r8_is_interlace_sync_and_video() {
-        (registers.crtc_r9_maximum_raster_address >> 1) + 1
-    } else {
-        registers.crtc_r9_maximum_raster_address + 1
     }
 }

--- a/ch22-core/src/video/crtc/address_control.rs
+++ b/ch22-core/src/video/crtc/address_control.rs
@@ -1,0 +1,20 @@
+use crate::video::VideoRegisters;
+
+#[derive(Default)]
+pub struct AddressControl {
+    address: u16,
+}
+
+impl AddressControl {
+    pub fn reset(&mut self, registers: &VideoRegisters) {
+        self.address = registers.r12_r13_screen_address();
+    }
+
+    pub fn advance_char_row(&mut self, registers: &VideoRegisters) {
+        self.address = (self.address + registers.crtc_r1_horizontal_displayed as u16) & 0x3FFF;
+    }
+
+    pub fn get_address(&self) -> u16 {
+        self.address
+    }
+}

--- a/ch22-core/src/video/crtc/beam_control.rs
+++ b/ch22-core/src/video/crtc/beam_control.rs
@@ -1,0 +1,24 @@
+use crate::video::MAX_LINES;
+
+#[derive(Default)]
+pub struct BeamControl {
+    scanline: u16,
+}
+
+impl BeamControl {
+    pub fn advance_scanline(&mut self) {
+        self.scanline += 1;
+
+        if self.scanline == MAX_LINES as u16 {
+            self.scanline = 0;
+        }
+    }
+
+    pub fn reset(&mut self) {
+        self.scanline = 0;
+    }
+
+    pub fn get_scanline(&self) -> u16 {
+        self.scanline
+    }
+}

--- a/ch22-core/src/video/crtc/char_raster_control.rs
+++ b/ch22-core/src/video/crtc/char_raster_control.rs
@@ -1,60 +1,60 @@
 use crate::video::VideoRegisters;
 
-pub enum CharRowPosition {
+pub enum CharRasterPosition {
     StartOfField,
     StartOfCharRow,
     VsyncStart,
 }
 
 #[derive(Default)]
-pub struct CharRowControl {
+pub struct CharRasterControl {
     char_row: u8,
-    char_raster: u8,
+    char_raster_in_row: u8,
 }
 
-impl CharRowControl {
+impl CharRasterControl {
     pub fn reset(&mut self) {
         self.char_row = 0;
-        self.char_raster = 0;
+        self.char_raster_in_row = 0;
     }
 
     pub fn advance_scanline(&mut self, registers: &VideoRegisters) {
         debug_assert!(registers.crtc_r4_vertical_total <= 0x7F); // r4 should only be 7 bit
         debug_assert!(registers.crtc_r5_vertical_total_adjust <= 0x1F); // r5 should only be 5 bit
 
-        self.char_raster += 1;
+        self.char_raster_in_row += 1;
 
         if self.char_row <= registers.crtc_r4_vertical_total
-            && self.char_raster >= registers.r8_r9_rasters_per_char()
+            && self.char_raster_in_row >= registers.r8_r9_rasters_per_char()
         {
             self.char_row += 1;
-            self.char_raster = 0;
+            self.char_raster_in_row = 0;
         }
 
         if self.char_row > registers.crtc_r4_vertical_total
-            && self.char_raster >= registers.crtc_r5_vertical_total_adjust
+            && self.char_raster_in_row >= registers.crtc_r5_vertical_total_adjust
         {
             self.reset();
         }
     }
 
-    pub fn get_position(&self, registers: &VideoRegisters) -> Option<CharRowPosition> {
-        if self.char_row == 0 && self.char_raster == 0 {
-            Some(CharRowPosition::StartOfField)
-        } else if self.char_raster == 0 {
-            Some(CharRowPosition::StartOfCharRow)
+    pub fn get_position(&self, registers: &VideoRegisters) -> Option<CharRasterPosition> {
+        if self.char_row == 0 && self.char_raster_in_row == 0 {
+            Some(CharRasterPosition::StartOfField)
+        } else if self.char_raster_in_row == 0 {
+            Some(CharRasterPosition::StartOfCharRow)
         } else if self.char_row == registers.crtc_r7_vertical_sync_position
             // after first raster of vsync pos
-            && self.char_raster == 1
+            && self.char_raster_in_row == 1
         {
-            Some(CharRowPosition::VsyncStart)
+            Some(CharRasterPosition::VsyncStart)
         } else {
             None
         }
     }
 
     pub fn is_at_start(&self) -> bool {
-        self.char_row == 0 && self.char_raster == 0
+        self.char_row == 0 && self.char_raster_in_row == 0
     }
 
     pub fn is_in_scan(&self, registers: &VideoRegisters) -> bool {
@@ -63,9 +63,9 @@ impl CharRowControl {
 
     pub fn get_raster_address_even(&self, registers: &VideoRegisters) -> u8 {
         if registers.r8_is_interlace_sync_and_video() {
-            self.char_raster << 1
+            self.char_raster_in_row << 1
         } else {
-            self.char_raster
+            self.char_raster_in_row
         }
     }
 

--- a/ch22-core/src/video/crtc/char_raster_control.rs
+++ b/ch22-core/src/video/crtc/char_raster_control.rs
@@ -57,7 +57,7 @@ impl CharRasterControl {
         self.char_row == 0 && self.char_raster_in_row == 0
     }
 
-    pub fn is_in_scan(&self, registers: &VideoRegisters) -> bool {
+    pub fn is_displayed(&self, registers: &VideoRegisters) -> bool {
         self.char_row < registers.crtc_r6_vertical_displayed
     }
 

--- a/ch22-core/src/video/crtc/char_row.rs
+++ b/ch22-core/src/video/crtc/char_row.rs
@@ -53,7 +53,7 @@ impl CharRowControl {
         }
     }
 
-    pub fn is_start_of_field(&self) -> bool {
+    pub fn is_at_start(&self) -> bool {
         self.char_row == 0 && self.char_raster == 0
     }
 

--- a/ch22-core/src/video/crtc/char_row.rs
+++ b/ch22-core/src/video/crtc/char_row.rs
@@ -1,0 +1,79 @@
+use crate::video::VideoRegisters;
+
+pub enum CharRowPosition {
+    StartOfField,
+    StartOfCharRow,
+    VsyncStart,
+}
+
+#[derive(Default)]
+pub struct CharRowControl {
+    char_row: u8,
+    char_raster: u8,
+}
+
+impl CharRowControl {
+    pub fn reset(&mut self) {
+        self.char_row = 0;
+        self.char_raster = 0;
+    }
+
+    pub fn advance_scanline(&mut self, registers: &VideoRegisters) {
+        debug_assert!(registers.crtc_r4_vertical_total <= 0x7F); // r4 should only be 7 bit
+        debug_assert!(registers.crtc_r5_vertical_total_adjust <= 0x1F); // r5 should only be 5 bit
+
+        self.char_raster += 1;
+
+        if self.char_row <= registers.crtc_r4_vertical_total
+            && self.char_raster >= registers.r8_r9_rasters_per_char()
+        {
+            self.char_row += 1;
+            self.char_raster = 0;
+        }
+
+        if self.char_row > registers.crtc_r4_vertical_total
+            && self.char_raster >= registers.crtc_r5_vertical_total_adjust
+        {
+            self.reset();
+        }
+    }
+
+    pub fn get_position(&self, registers: &VideoRegisters) -> Option<CharRowPosition> {
+        if self.char_row == 0 && self.char_raster == 0 {
+            Some(CharRowPosition::StartOfField)
+        } else if self.char_raster == 0 {
+            Some(CharRowPosition::StartOfCharRow)
+        } else if self.char_row == registers.crtc_r7_vertical_sync_position
+            // after first raster of vsync pos
+            && self.char_raster == 1
+        {
+            Some(CharRowPosition::VsyncStart)
+        } else {
+            None
+        }
+    }
+
+    pub fn is_start_of_field(&self) -> bool {
+        self.char_row == 0 && self.char_raster == 0
+    }
+
+    pub fn is_in_scan(&self, registers: &VideoRegisters) -> bool {
+        self.char_row < registers.crtc_r6_vertical_displayed
+    }
+
+    pub fn get_raster_address_even(&self, registers: &VideoRegisters) -> u8 {
+        if registers.r8_is_interlace_sync_and_video() {
+            self.char_raster << 1
+        } else {
+            self.char_raster
+        }
+    }
+
+    pub fn get_raster_address_odd(&self, registers: &VideoRegisters) -> u8 {
+        if registers.r8_is_interlace_sync_and_video() {
+            self.get_raster_address_even(registers) + 1
+        } else {
+            self.get_raster_address_even(registers)
+        }
+    }
+}

--- a/ch22-core/src/video/crtc/tests.rs
+++ b/ch22-core/src/video/crtc/tests.rs
@@ -25,30 +25,10 @@ fn should_increment_scanline_by_1_on_each_call() {
     let mut crtc = Crtc::default();
     crtc.init(&registers);
 
-    let expected_scanlines: [u16; 10] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+    let expected_scanlines: Vec<u16> = (0..50).map(|i| i as u16).collect();
 
     for (index, expected) in expected_scanlines.iter().enumerate() {
         let actual = crtc.get_snapshot_params(&registers).beam_scanline;
-
-        assert_eq!(actual, *expected, "mismatch at index {index}");
-
-        crtc.advance_scanline(&registers);
-    }
-}
-
-#[test]
-fn should_cycle_raster_address_even_pattern_after_char_scanlines_calls() {
-    let mut registers = create_default_registers();
-    registers.crtc_r9_maximum_raster_address = 7;
-    registers.crtc_r1_horizontal_displayed = 80;
-
-    let mut crtc = Crtc::default();
-    crtc.init(&registers);
-
-    let expected_pattern = [0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7];
-
-    for (index, expected) in expected_pattern.iter().enumerate() {
-        let actual = crtc.get_snapshot_params(&registers).raster_address_even;
 
         assert_eq!(actual, *expected, "mismatch at index {index}");
 
@@ -189,39 +169,33 @@ fn should_stop_incrementing_addr_after_char_line_exceeds_vertical_total() {
 }
 
 #[test]
-fn should_maintain_consistent_scanline_delta() {
-    let registers = create_default_registers();
-    let mut crtc = Crtc::default();
-    crtc.init(&registers);
-
-    let expected_scanlines: Vec<u16> = (0..50).map(|i| i as u16).collect();
-
-    for (index, expected) in expected_scanlines.iter().enumerate() {
-        let actual = crtc.get_snapshot_params(&registers).beam_scanline;
-
-        assert_eq!(actual, *expected, "mismatch at index {index}");
-
-        crtc.advance_scanline(&registers);
-    }
-}
-
-#[test]
 fn should_track_raster_address_progression_correctly() {
-    let mut registers = create_default_registers();
-    registers.crtc_r9_maximum_raster_address = 3;
-    registers.crtc_r8_interlace_and_skew = 0x00;
+    // Test raster_address_even cycles correctly with various r9 values
+    let test_cases = [
+        (1, [0, 1, 0, 1, 0, 1, 0, 1, 0, 1]),
+        (3, [0, 1, 2, 3, 0, 1, 2, 3, 0, 1]),
+        (7, [0, 1, 2, 3, 4, 5, 6, 7, 0, 1]),
+    ];
 
-    let mut crtc = Crtc::default();
-    crtc.init(&registers);
+    for (r9_value, expected_pattern) in test_cases {
+        let mut registers = create_default_registers();
+        registers.crtc_r9_maximum_raster_address = r9_value;
+        registers.crtc_r8_interlace_and_skew = 0x00;
 
-    let expected_pattern = [0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3];
+        let mut crtc = Crtc::default();
+        crtc.init(&registers);
 
-    for (index, expected) in expected_pattern.iter().enumerate() {
-        let actual = crtc.get_snapshot_params(&registers).raster_address_even;
+        for (index, expected) in expected_pattern.iter().enumerate() {
+            let actual = crtc.get_snapshot_params(&registers).raster_address_even;
 
-        assert_eq!(actual, *expected, "mismatch at index {index}");
+            assert_eq!(
+                actual, *expected,
+                "mismatch at index {index} for r9={}",
+                r9_value
+            );
 
-        crtc.advance_scanline(&registers);
+            crtc.advance_scanline(&registers);
+        }
     }
 }
 
@@ -387,9 +361,9 @@ fn should_maintain_consistent_next_scanline_trigger_in_both_frequency_modes() {
     // ula_control bit 4 selects frequency: 0=normal, 1=high
     // Trigger = (horizontal_total + 1) * clock_divisor
     // Normal mode: (127+1) * 2 = 256, High freq: (127+1) * 1 = 128
-    let test_cases = [(0x00, 256u16), (0x10, 128u16)];
+    let frequency_test_cases = [(0x00, 256u16), (0x10, 128u16)];
 
-    for (ula_control, expected_trigger) in test_cases {
+    for (ula_control, expected_trigger) in frequency_test_cases {
         let mut registers = create_default_registers();
         registers.crtc_r0_horizontal_total = 127;
         registers.ula_control = ula_control;
@@ -402,7 +376,11 @@ fn should_maintain_consistent_next_scanline_trigger_in_both_frequency_modes() {
         for (index, expected) in expected_triggers.iter().enumerate() {
             let actual = crtc.get_next_scanline_trigger(&registers);
 
-            assert_eq!(actual, *expected, "mismatch at index {index}");
+            assert_eq!(
+                actual, *expected,
+                "mismatch at index {index} for ula_control={:#04x}",
+                ula_control
+            );
 
             crtc.advance_scanline(&registers);
         }
@@ -425,28 +403,6 @@ fn beam_reset_should_only_occur_at_boundaries() {
             actual_beam_reset, expected_beam_reset,
             "mismatch at iteration {iteration}"
         );
-
-        crtc.advance_scanline(&registers);
-    }
-}
-
-#[test]
-fn address_should_increment_by_horizontal_displayed_per_char_line() {
-    let mut registers = create_default_registers();
-    registers.crtc_r1_horizontal_displayed = 0x28;
-    registers.crtc_r9_maximum_raster_address = 1; // 2 scanlines per char line
-    registers.crtc_r4_vertical_total = 10;
-
-    let mut crtc = Crtc::default();
-    crtc.init(&registers);
-
-    // Address advances by horizontal_displayed (0x28) after each char line completes
-    let expected_addresses = [0x2000, 0x2000, 0x2028, 0x2028, 0x2050, 0x2050];
-
-    for (index, expected) in expected_addresses.iter().enumerate() {
-        let actual = crtc.get_snapshot_params(&registers).address;
-
-        assert_eq!(actual, *expected, "mismatch at index {index}");
 
         crtc.advance_scanline(&registers);
     }
@@ -669,31 +625,6 @@ fn should_maintain_consistent_trigger_values_across_multiple_frames() {
 
     for (index, expected) in expected_triggers.iter().enumerate() {
         let actual = crtc.get_next_scanline_trigger(&registers);
-
-        assert_eq!(actual, *expected, "mismatch at index {index}");
-
-        crtc.advance_scanline(&registers);
-    }
-}
-
-#[test]
-fn should_show_pattern_stability_across_multiple_complete_frames() {
-    let mut registers = create_default_registers();
-    registers.crtc_r9_maximum_raster_address = 1; // 2 scanlines per char
-    registers.crtc_r4_vertical_total = 2; // 3 char lines
-    registers.crtc_r5_vertical_total_adjust = 0;
-    registers.crtc_r1_horizontal_displayed = 50;
-
-    let mut crtc = Crtc::default();
-    crtc.init(&registers);
-
-    // Frame = 3 char lines * 2 scanlines = 6 scanlines.
-    // Test 17 scanlines = 2 complete frames + 5 scanlines into 3rd frame.
-    // Scanline counter increments continuously without resetting
-    let expected_scanlines = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
-
-    for (index, expected) in expected_scanlines.iter().enumerate() {
-        let actual = crtc.get_snapshot_params(&registers).beam_scanline;
 
         assert_eq!(actual, *expected, "mismatch at index {index}");
 

--- a/ch22-core/src/video/crtc/tests.rs
+++ b/ch22-core/src/video/crtc/tests.rs
@@ -76,7 +76,7 @@ fn should_stop_incrementing_addr_after_char_line_exceeds_vertical_total() {
     // After char line 2 exceeds vertical_total (2), address remains at 0x2064
     // until frame resets at scanline 6, then pattern repeats
     let expected = [
-        // address, in_scan, scanline, raster_address_even
+        // address, is_displayed, scanline, raster_address_even
         (0x2000, true, 0, 0),  // char line 0, raster 0
         (0x2000, true, 1, 1),  // char line 0, raster 1
         (0x2032, true, 2, 0),  // char line 1, raster 0
@@ -89,7 +89,7 @@ fn should_stop_incrementing_addr_after_char_line_exceeds_vertical_total() {
         (0x2032, true, 9, 1),
     ];
 
-    for (index, (expected_address, expected_in_scan, expected_scanline, expected_raster)) in
+    for (index, (expected_address, expected_is_displayed, expected_scanline, expected_raster)) in
         expected.iter().enumerate()
     {
         let actual = crtc.get_snapshot_params(&registers);
@@ -99,12 +99,12 @@ fn should_stop_incrementing_addr_after_char_line_exceeds_vertical_total() {
             "address mismatch at index {index}",
         );
         assert_eq!(
-            actual.in_scan, *expected_in_scan,
-            "in_scan mismatch at index {index}",
+            actual.is_displayed, *expected_is_displayed,
+            "is_displayed mismatch at index {index}",
         );
         assert_eq!(
             actual.beam_scanline, *expected_scanline,
-            "scanline mismatch at index {index}",
+            "beam_scanline mismatch at index {index}",
         );
         assert_eq!(
             actual.raster_address_even, *expected_raster,
@@ -204,7 +204,7 @@ fn should_trigger_vsync_at_correct_positions() {
 // ============================================================================
 
 #[test]
-fn should_transition_in_scan_from_true_to_false_at_display_boundary() {
+fn should_transition_is_displayed_from_true_to_false_at_display_boundary() {
     let registers = VideoRegisters {
         crtc_r4_vertical_total: 10,
         crtc_r6_vertical_displayed: 2, // 2 character lines displayed
@@ -215,11 +215,11 @@ fn should_transition_in_scan_from_true_to_false_at_display_boundary() {
     let mut crtc = Crtc::default();
     crtc.init(&registers);
 
-    // in_scan is true for 2 char lines * 2 scanlines = 4 scanlines, then false
+    // is_displayed is true for 2 char lines * 2 scanlines = 4 scanlines, then false
     let expected_pattern = [true, true, true, true, false, false, false];
 
     for (index, expected) in expected_pattern.iter().enumerate() {
-        let actual = crtc.get_snapshot_params(&registers).in_scan;
+        let actual = crtc.get_snapshot_params(&registers).is_displayed;
 
         assert_eq!(actual, *expected, "mismatch at index {index}");
 
@@ -381,7 +381,7 @@ fn should_respect_vertical_total_adjust_when_completing_frames() {
             (0x2000, true),
         ];
 
-        for (index, (expected_address, expected_in_scan)) in expected.iter().enumerate() {
+        for (index, (expected_address, expected_is_displayed)) in expected.iter().enumerate() {
             let actual = crtc.get_snapshot_params(&registers);
 
             assert_eq!(
@@ -389,8 +389,8 @@ fn should_respect_vertical_total_adjust_when_completing_frames() {
                 "{mode_name}: address mismatch at index {index}",
             );
             assert_eq!(
-                actual.in_scan, *expected_in_scan,
-                "{mode_name}: in_scan mismatch at index {index}",
+                actual.is_displayed, *expected_is_displayed,
+                "{mode_name}: is_displayed mismatch at index {index}",
             );
 
             crtc.advance_scanline(&registers);
@@ -639,7 +639,7 @@ fn should_handle_minimal_display_area() {
     let expected_pattern = [true, true, false, false, false];
 
     for (index, expected) in expected_pattern.iter().enumerate() {
-        let actual = crtc.get_snapshot_params(&registers).in_scan;
+        let actual = crtc.get_snapshot_params(&registers).is_displayed;
 
         assert_eq!(actual, *expected, "mismatch at index {index}");
 

--- a/ch22-core/src/video/crtc/tests.rs
+++ b/ch22-core/src/video/crtc/tests.rs
@@ -33,12 +33,11 @@ fn should_increment_scanline_by_1_on_each_call() {
     let expected_scanlines: [u16; 10] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
 
     for (index, expected) in expected_scanlines.iter().enumerate() {
-        let actual = crtc
-            .advance_scanline(&registers)
-            .snapshot_params
-            .beam_scanline;
+        let actual = crtc.get_snapshot_params(&registers).beam_scanline;
 
         assert_eq!(actual, *expected, "mismatch at index {index}");
+
+        crtc.advance_scanline(&registers);
     }
 }
 
@@ -53,12 +52,11 @@ fn should_cycle_raster_address_even_pattern_after_char_scanlines_calls() {
     let expected_pattern = [0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7];
 
     for (index, expected) in expected_pattern.iter().enumerate() {
-        let actual = crtc
-            .advance_scanline(&registers)
-            .snapshot_params
-            .raster_address_even;
+        let actual = crtc.get_snapshot_params(&registers).raster_address_even;
 
         assert_eq!(actual, *expected, "mismatch at index {index}");
+
+        crtc.advance_scanline(&registers);
     }
 }
 
@@ -77,9 +75,11 @@ fn should_advance_address_by_horizontal_displayed_after_char_scanlines() {
     ];
 
     for (index, expected) in expected_addresses.iter().enumerate() {
-        let actual = crtc.advance_scanline(&registers).snapshot_params.address;
+        let actual = crtc.get_snapshot_params(&registers).address;
 
         assert_eq!(actual, *expected, "mismatch at index {index}");
+
+        crtc.advance_scanline(&registers);
     }
 }
 
@@ -96,14 +96,16 @@ fn should_transition_in_scan_from_true_to_false_at_display_boundary() {
     let expected_pattern = [true, true, true, true, false, false, false];
 
     for (index, expected) in expected_pattern.iter().enumerate() {
-        let actual = crtc.advance_scanline(&registers).snapshot_params.in_scan;
+        let actual = crtc.get_snapshot_params(&registers).in_scan;
 
         assert_eq!(actual, *expected, "mismatch at index {index}");
+
+        crtc.advance_scanline(&registers);
     }
 }
 
 #[test]
-fn should_return_field_complete_true_at_max_lines() {
+fn should_return_beam_scanline_0_at_max_lines() {
     let mut registers = create_default_registers();
     // Set vsync position to max to prevent normal field completion,
     // forcing the hardware limit (MAX_LINES) to trigger instead
@@ -111,19 +113,25 @@ fn should_return_field_complete_true_at_max_lines() {
 
     let mut crtc = setup_test(&registers);
 
-    let mut field_complete_iteration: i32 = -1;
-    for i in 0..(crate::video::MAX_LINES + 10) {
-        let result = crtc.advance_scanline(&registers);
-        if result.field_complete {
-            field_complete_iteration = i as i32;
+    // Skip iteration 0 (initial state with beam_scanline == 0)
+    crtc.advance_scanline(&registers);
+
+    let mut beam_scanline_0_iteration: i32 = -1;
+    for i in 1..(crate::video::MAX_LINES + 10) {
+        let beam_scanline = crtc.get_snapshot_params(&registers).beam_scanline;
+
+        if beam_scanline == 0 {
+            beam_scanline_0_iteration = i as i32;
             break;
         }
+
+        crtc.advance_scanline(&registers);
     }
 
     assert_eq!(
-        field_complete_iteration,
-        crate::video::MAX_LINES as i32 - 1,
-        "field_complete should occur at iteration",
+        beam_scanline_0_iteration,
+        crate::video::MAX_LINES as i32,
+        "beam scanline should be 0 at iteration MAX_LINES (after hardware limit reset)",
     );
 }
 
@@ -157,7 +165,7 @@ fn should_stop_incrementing_addr_after_char_line_exceeds_vertical_total() {
     for (index, (expected_address, expected_in_scan, expected_scanline, expected_raster)) in
         expected.iter().enumerate()
     {
-        let actual = crtc.advance_scanline(&registers).snapshot_params;
+        let actual = crtc.get_snapshot_params(&registers);
 
         assert_eq!(
             actual.address, *expected_address,
@@ -175,6 +183,8 @@ fn should_stop_incrementing_addr_after_char_line_exceeds_vertical_total() {
             actual.raster_address_even, *expected_raster,
             "raster_address_even mismatch at index {index}",
         );
+
+        crtc.advance_scanline(&registers);
     }
 }
 
@@ -186,12 +196,11 @@ fn should_maintain_consistent_scanline_delta() {
     let expected_scanlines: Vec<u16> = (0..50).map(|i| i as u16).collect();
 
     for (index, expected) in expected_scanlines.iter().enumerate() {
-        let actual = crtc
-            .advance_scanline(&registers)
-            .snapshot_params
-            .beam_scanline;
+        let actual = crtc.get_snapshot_params(&registers).beam_scanline;
 
         assert_eq!(actual, *expected, "mismatch at index {index}");
+
+        crtc.advance_scanline(&registers);
     }
 }
 
@@ -206,12 +215,11 @@ fn should_track_raster_address_progression_correctly() {
     let expected_pattern = [0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3];
 
     for (index, expected) in expected_pattern.iter().enumerate() {
-        let actual = crtc
-            .advance_scanline(&registers)
-            .snapshot_params
-            .raster_address_even;
+        let actual = crtc.get_snapshot_params(&registers).raster_address_even;
 
         assert_eq!(actual, *expected, "mismatch at index {index}");
+
+        crtc.advance_scanline(&registers);
     }
 }
 
@@ -223,11 +231,11 @@ fn should_trigger_vsync_at_correct_positions() {
     let test_cases = [
         // r7_vertical_sync_position, r3_sync_width, expected_indices, length
         (1, 0x00, vec![], 10), // vsync at char 1 (scanline 2), width=0: no vsync
-        (2, 0x10, vec![4], 15), // vsync at char 2 (scanline 4), width=1
-        (2, 0x20, vec![4, 5], 20), // vsync at char 2 (scanline 4), width=2
-        (3, 0x20, vec![6, 7], 20), // vsync at char 3 (scanline 6), width=2
-        (2, 0x30, vec![4, 5, 6], 20), // vsync at char 2 (scanline 4), width=3
-        (2, 0x40, vec![4, 5, 6, 7], 15), // vsync at char 2 (scanline 4), width=4
+        (2, 0x10, vec![5], 15), // vsync at char 2 (scanline 4), width=1
+        (2, 0x20, vec![5, 6], 20), // vsync at char 2 (scanline 4), width=2
+        (3, 0x20, vec![7, 8], 20), // vsync at char 3 (scanline 6), width=2
+        (2, 0x30, vec![5, 6, 7], 20), // vsync at char 2 (scanline 4), width=3
+        (2, 0x40, vec![5, 6, 7, 8], 15), // vsync at char 2 (scanline 4), width=4
     ];
 
     for (r7_vertical_sync_position, r3_sync_width, expected_indices, length) in test_cases {
@@ -240,7 +248,7 @@ fn should_trigger_vsync_at_correct_positions() {
         let mut crtc = setup_test(&registers);
 
         for index in 0..length {
-            let actual = crtc.advance_scanline(&registers).vsync;
+            let actual = crtc.is_in_vsync();
             let expected = expected_indices.contains(&index);
 
             assert_eq!(
@@ -248,6 +256,8 @@ fn should_trigger_vsync_at_correct_positions() {
                 "vsync mismatch at index {index} for r7_vertical_sync_position={}, r3_sync_width={:#04x}",
                 r7_vertical_sync_position, r3_sync_width
             );
+
+            crtc.advance_scanline(&registers);
         }
     }
 }
@@ -269,42 +279,49 @@ fn should_complete_frame_at_correct_boundary() {
     ];
 
     for (index, expected) in expected_addresses.iter().enumerate() {
-        let actual = crtc.advance_scanline(&registers).snapshot_params.address;
+        let actual = crtc.get_snapshot_params(&registers).address;
 
         assert_eq!(actual, *expected, "mismatch at index {index}");
+
+        crtc.advance_scanline(&registers);
     }
 }
 
 #[test]
-fn should_reset_scanline_after_field_complete() {
+fn should_reset_scanline_after_beam_reset() {
     let registers = create_default_registers();
     let mut crtc = setup_test(&registers);
 
-    // Advance to iteration 160 where field_complete should occur
+    assert!(
+        crtc.is_beam_reset(),
+        "is_beam_reset should be true for first iteration"
+    );
+
+    crtc.advance_scanline(&registers);
+
+    // Advance to iteration 160 where next beam_reset should occur
     for iteration in 0..160 {
-        let result = crtc.advance_scanline(&registers);
-        assert!(
-            !result.field_complete,
-            "field_complete should be false before iteration 160 ({iteration})"
+        let actual = crtc.is_beam_reset();
+
+        assert_eq!(
+            actual, false,
+            "is_beam_reset should be false before iteration 160 ({iteration})"
         );
+
+        crtc.advance_scanline(&registers);
     }
 
-    // At iteration 160: field_complete should be true and scanline should be 160
-    let result_at_160 = crtc.advance_scanline(&registers);
-    assert!(
-        result_at_160.field_complete,
-        "field_complete should be true at iteration 160"
-    );
-    assert_eq!(
-        result_at_160.snapshot_params.beam_scanline, 160,
-        "scanline should be 160 at field_complete"
-    );
+    // At iteration 160: is_beam_reset should be true and scanline should be 0
+    let snapshot_params_at_160 = crtc.get_snapshot_params(&registers);
+    let beam_reset_at_160 = crtc.is_beam_reset();
 
-    // At iteration 161: scanline should reset to 0
-    let result_at_161 = crtc.advance_scanline(&registers);
     assert_eq!(
-        result_at_161.snapshot_params.beam_scanline, 0,
-        "scanline should reset to 0 after field_complete"
+        beam_reset_at_160, true,
+        "is_beam_reset should be true at iteration 160"
+    );
+    assert_eq!(
+        snapshot_params_at_160.beam_scanline, 0,
+        "scanline should be 0 at beam_reset"
     );
 }
 
@@ -343,7 +360,7 @@ fn should_respect_vertical_total_adjust_when_completing_frames() {
         ];
 
         for (index, (expected_address, expected_in_scan)) in expected.iter().enumerate() {
-            let actual = crtc.advance_scanline(&registers).snapshot_params;
+            let actual = crtc.get_snapshot_params(&registers);
 
             assert_eq!(
                 actual.address, *expected_address,
@@ -353,6 +370,8 @@ fn should_respect_vertical_total_adjust_when_completing_frames() {
                 actual.in_scan, *expected_in_scan,
                 "{mode_name}: in_scan mismatch at index {index}",
             );
+
+            crtc.advance_scanline(&registers);
         }
     }
 }
@@ -374,28 +393,32 @@ fn should_maintain_consistent_next_scanline_trigger_in_both_frequency_modes() {
         let expected_triggers = [expected_trigger; 20];
 
         for (index, expected) in expected_triggers.iter().enumerate() {
-            let actual = crtc.advance_scanline(&registers).next_scanline_trigger;
+            let actual = crtc.get_next_scanline_trigger(&registers);
 
             assert_eq!(actual, *expected, "mismatch at index {index}");
+
+            crtc.advance_scanline(&registers);
         }
     }
 }
 
 #[test]
-fn field_complete_should_only_occur_at_boundaries() {
+fn beam_reset_should_only_occur_at_boundaries() {
     let registers = create_default_registers();
     let mut crtc = setup_test(&registers);
 
     // With default registers: 20 char lines displayed * 8 scanlines/char = 160 scanlines
-    // field_complete should occur exactly once at scanline 160
+    // beam_reset should occur at 0 and 161
     for iteration in 0..165 {
-        let actual_field_complete = crtc.advance_scanline(&registers).field_complete;
-        let expected_field_complete = iteration == 160;
+        let actual_beam_reset = crtc.is_beam_reset();
+        let expected_beam_reset = iteration == 0 || iteration == 161;
 
         assert_eq!(
-            actual_field_complete, expected_field_complete,
+            actual_beam_reset, expected_beam_reset,
             "mismatch at iteration {iteration}"
         );
+
+        crtc.advance_scanline(&registers);
     }
 }
 
@@ -412,9 +435,11 @@ fn address_should_increment_by_horizontal_displayed_per_char_line() {
     let expected_addresses = [0x2000, 0x2000, 0x2028, 0x2028, 0x2050, 0x2050];
 
     for (index, expected) in expected_addresses.iter().enumerate() {
-        let actual = crtc.advance_scanline(&registers).snapshot_params.address;
+        let actual = crtc.get_snapshot_params(&registers).address;
 
         assert_eq!(actual, *expected, "mismatch at index {index}");
+
+        crtc.advance_scanline(&registers);
     }
 }
 
@@ -443,7 +468,7 @@ fn raster_address_odd_should_equal_even_plus_one_when_interlaced() {
     ];
 
     for (index, (expected_even, expected_odd)) in expected.iter().enumerate() {
-        let actual = crtc.advance_scanline(&registers).snapshot_params;
+        let actual = crtc.get_snapshot_params(&registers);
 
         assert_eq!(
             actual.raster_address_even, *expected_even,
@@ -453,6 +478,8 @@ fn raster_address_odd_should_equal_even_plus_one_when_interlaced() {
             actual.raster_address_odd, *expected_odd,
             "raster_address_odd mismatch at index {index}",
         );
+
+        crtc.advance_scanline(&registers);
     }
 }
 
@@ -478,7 +505,7 @@ fn raster_address_odd_should_equal_even_when_not_interlaced() {
     ];
 
     for (index, (expected_even, expected_odd)) in expected.iter().enumerate() {
-        let actual = crtc.advance_scanline(&registers).snapshot_params;
+        let actual = crtc.get_snapshot_params(&registers);
 
         assert_eq!(
             actual.raster_address_even, *expected_even,
@@ -488,6 +515,8 @@ fn raster_address_odd_should_equal_even_when_not_interlaced() {
             actual.raster_address_odd, *expected_odd,
             "raster_address_odd mismatch at index {index}",
         );
+
+        crtc.advance_scanline(&registers);
     }
 }
 
@@ -509,12 +538,14 @@ fn address_should_only_update_from_start_registers_at_frame_boundary() {
     ];
 
     for (index, expected) in first_expected_addresses.iter().enumerate() {
-        let actual = crtc.advance_scanline(&registers).snapshot_params.address;
+        let actual = crtc.get_snapshot_params(&registers).address;
 
         assert_eq!(
             actual, *expected,
             "mismatch at index {index} (first sequence)"
         );
+
+        crtc.advance_scanline(&registers);
     }
 
     // Change start address register mid-test
@@ -525,12 +556,14 @@ fn address_should_only_update_from_start_registers_at_frame_boundary() {
     let second_expected_addresses = [0x2032, 0x2032, 0x2064, 0x2064, 0x3000, 0x3000];
 
     for (index, expected) in second_expected_addresses.iter().enumerate() {
-        let actual = crtc.advance_scanline(&registers).snapshot_params.address;
+        let actual = crtc.get_snapshot_params(&registers).address;
 
         assert_eq!(
             actual, *expected,
             "mismatch at index {index} (second sequence)"
         );
+
+        crtc.advance_scanline(&registers);
     }
 }
 
@@ -546,12 +579,11 @@ fn should_handle_scan_lines_per_char_zero() {
     let expected_addresses = [0, 0, 0, 0, 0];
 
     for (index, expected) in expected_addresses.iter().enumerate() {
-        let actual = crtc
-            .advance_scanline(&registers)
-            .snapshot_params
-            .raster_address_even;
+        let actual = crtc.get_snapshot_params(&registers).raster_address_even;
 
         assert_eq!(actual, *expected, "mismatch at index {index}");
+
+        crtc.advance_scanline(&registers);
     }
 }
 
@@ -567,9 +599,11 @@ fn should_handle_minimal_display_area() {
     let expected_pattern = [true, true, false, false, false];
 
     for (index, expected) in expected_pattern.iter().enumerate() {
-        let actual = crtc.advance_scanline(&registers).snapshot_params.in_scan;
+        let actual = crtc.get_snapshot_params(&registers).in_scan;
 
         assert_eq!(actual, *expected, "mismatch at index {index}");
+
+        crtc.advance_scanline(&registers);
     }
 }
 
@@ -579,12 +613,12 @@ fn should_handle_horizontal_total_zero() {
     registers.crtc_r0_horizontal_total = 0; // Edge case: minimum value
     registers.ula_control = 0x00;
 
-    let mut crtc = setup_test(&registers);
+    let crtc = setup_test(&registers);
 
-    let actual = crtc.advance_scanline(&registers);
+    let actual = crtc.get_next_scanline_trigger(&registers);
 
     // Trigger = (0 + 1) * 2 = 2
-    assert_eq!(actual.next_scanline_trigger, 2);
+    assert_eq!(actual, 2);
 }
 
 #[test]
@@ -593,12 +627,12 @@ fn should_handle_horizontal_total_255() {
     registers.crtc_r0_horizontal_total = 255; // Edge case: maximum value
     registers.ula_control = 0x10; // High frequency mode
 
-    let mut crtc = setup_test(&registers);
+    let crtc = setup_test(&registers);
 
-    let actual = crtc.advance_scanline(&registers);
+    let actual = crtc.get_next_scanline_trigger(&registers);
 
     // Trigger = (255 + 1) * 1 = 256 (high freq mode uses divisor 1)
-    assert_eq!(actual.next_scanline_trigger, 256);
+    assert_eq!(actual, 256);
 }
 
 #[test]
@@ -617,9 +651,11 @@ fn should_maintain_consistent_trigger_values_across_multiple_frames() {
     let expected_triggers = [256u16; 17];
 
     for (index, expected) in expected_triggers.iter().enumerate() {
-        let actual = crtc.advance_scanline(&registers).next_scanline_trigger;
+        let actual = crtc.get_next_scanline_trigger(&registers);
 
         assert_eq!(actual, *expected, "mismatch at index {index}");
+
+        crtc.advance_scanline(&registers);
     }
 }
 
@@ -639,12 +675,11 @@ fn should_show_pattern_stability_across_multiple_complete_frames() {
     let expected_scanlines = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
 
     for (index, expected) in expected_scanlines.iter().enumerate() {
-        let actual = crtc
-            .advance_scanline(&registers)
-            .snapshot_params
-            .beam_scanline;
+        let actual = crtc.get_snapshot_params(&registers).beam_scanline;
 
         assert_eq!(actual, *expected, "mismatch at index {index}");
+
+        crtc.advance_scanline(&registers);
     }
 }
 
@@ -665,12 +700,14 @@ fn should_toggle_interlace_frame_and_double_trigger_on_alternate_frames() {
     // In interlace sync mode, every 4th scanline (at char line 1 of odd frames)
     // gets double trigger (512) for half-line offset. Pattern: 256,256,256,512,...
     let expected_triggers = [
-        256, 256, 256, 512, 256, 256, 256, 256, 256, 256, 256, 512, 256,
+        256, 256, 256, 256, 512, 256, 256, 256, 256, 256, 256, 256, 512, 256,
     ];
 
     for (index, expected) in expected_triggers.iter().enumerate() {
-        let actual = crtc.advance_scanline(&registers).next_scanline_trigger;
+        let actual = crtc.get_next_scanline_trigger(&registers);
 
         assert_eq!(actual, *expected, "mismatch at index {index}");
+
+        crtc.advance_scanline(&registers);
     }
 }

--- a/ch22-core/src/video/crtc/tests.rs
+++ b/ch22-core/src/video/crtc/tests.rs
@@ -34,7 +34,10 @@ fn should_increment_scanline_by_1_on_each_call() {
     let expected_scanlines: [u16; 10] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
 
     for (index, expected) in expected_scanlines.iter().enumerate() {
-        let actual = crtc.advance_scanline(&registers).snapshot_params.scanline;
+        let actual = crtc
+            .advance_scanline(&registers)
+            .snapshot_params
+            .beam_scanline;
 
         assert_eq!(actual, *expected, "mismatch at index {index}");
     }
@@ -166,7 +169,7 @@ fn should_stop_incrementing_addr_after_char_line_exceeds_vertical_total() {
             "in_scan mismatch at index {index}",
         );
         assert_eq!(
-            actual.scanline, *expected_scanline,
+            actual.beam_scanline, *expected_scanline,
             "scanline mismatch at index {index}",
         );
         assert_eq!(
@@ -184,7 +187,10 @@ fn should_maintain_consistent_scanline_delta() {
     let expected_scanlines: Vec<u16> = (0..50).map(|i| i as u16).collect();
 
     for (index, expected) in expected_scanlines.iter().enumerate() {
-        let actual = crtc.advance_scanline(&registers).snapshot_params.scanline;
+        let actual = crtc
+            .advance_scanline(&registers)
+            .snapshot_params
+            .beam_scanline;
 
         assert_eq!(actual, *expected, "mismatch at index {index}");
     }
@@ -291,59 +297,64 @@ fn should_reset_scanline_after_field_complete() {
         "field_complete should be true at iteration 160"
     );
     assert_eq!(
-        result_at_160.snapshot_params.scanline, 160,
+        result_at_160.snapshot_params.beam_scanline, 160,
         "scanline should be 160 at field_complete"
     );
 
     // At iteration 161: scanline should reset to 0
     let result_at_161 = crtc.advance_scanline(&registers);
     assert_eq!(
-        result_at_161.snapshot_params.scanline, 0,
+        result_at_161.snapshot_params.beam_scanline, 0,
         "scanline should reset to 0 after field_complete"
     );
 }
 
 #[test]
 fn should_respect_vertical_total_adjust_when_completing_frames() {
-    let mut registers = create_default_registers();
-    registers.crtc_r9_maximum_raster_address = 1; // 2 scanlines per char line
-    registers.crtc_r4_vertical_total = 2; // 3 char lines
-    registers.crtc_r5_vertical_total_adjust = 3; // +3 extra scanlines at end
-    registers.crtc_r1_horizontal_displayed = 50; // 0x32
-    registers.crtc_r6_vertical_displayed = 2;
-    registers.crtc_r7_vertical_sync_position = 0;
-
-    let mut crtc = setup_test(&registers);
-
-    // Frame = (3 char lines * 2 scanlines) + 3 adjust = 9 scanlines total.
-    // Address increments stop after char lines complete, but scanlines continue.
-    // During the 3 adjust scanlines (6-8), address stays at 0x2096
-    let expected = [
-        // address, inScan
-        (0x2000, true),  // char line 0, scanline 0
-        (0x2000, true),  // char line 0, scanline 1
-        (0x2032, true),  // char line 1, scanline 2
-        (0x2032, true),  // char line 1, scanline 3
-        (0x2064, false), // char line 2, scanline 4
-        (0x2064, false), // char line 2, scanline 5
-        (0x2096, false), // adjust scanline 6 (address frozen)
-        (0x2096, false), // adjust scanline 7 (address frozen)
-        (0x2096, false), // adjust scanline 8 (address frozen)
-        (0x2000, true),  // frame reset, scanline 9
-        (0x2000, true),
+    let total_adjust_cases = [
+        // name, r8, r9
+        ("normal", 0x00, 1),
+        ("interlace sync and video", 0x03, 2),
     ];
 
-    for (index, (expected_address, expected_in_scan)) in expected.iter().enumerate() {
-        let actual = crtc.advance_scanline(&registers).snapshot_params;
+    for (mode_name, r8_interlace_and_skew, r9_maximum_raster_address) in total_adjust_cases {
+        let mut registers = create_default_registers();
+        registers.crtc_r1_horizontal_displayed = 50;
+        registers.crtc_r4_vertical_total = 2;
+        registers.crtc_r5_vertical_total_adjust = 3;
+        registers.crtc_r6_vertical_displayed = 2;
+        registers.crtc_r7_vertical_sync_position = 0;
+        registers.crtc_r8_interlace_and_skew = r8_interlace_and_skew;
+        registers.crtc_r9_maximum_raster_address = r9_maximum_raster_address;
+        registers.ula_control = 0x00;
 
-        assert_eq!(
-            actual.in_scan, *expected_in_scan,
-            "in_scan mismatch at index {index}",
-        );
-        assert_eq!(
-            actual.address, *expected_address,
-            "address mismatch at index {index}",
-        );
+        let mut crtc = setup_test(&registers);
+
+        let expected = [
+            (0x2000, true),  // char line 0, raster 0
+            (0x2000, true),  // char line 0, raster 1
+            (0x2032, true),  // char line 1, raster 0
+            (0x2032, true),  // char line 1, raster 1
+            (0x2064, false), // char line 2, raster 0
+            (0x2064, false), // char line 2, raster 1
+            (0x2096, false), // adjust scanline 0 (address frozen)
+            (0x2096, false), // adjust scanline 1 (address frozen)
+            (0x2096, false), // adjust scanline 2 (raster wraps, frame resets after)
+            (0x2000, true),
+        ];
+
+        for (index, (expected_address, expected_in_scan)) in expected.iter().enumerate() {
+            let actual = crtc.advance_scanline(&registers).snapshot_params;
+
+            assert_eq!(
+                actual.address, *expected_address,
+                "{mode_name}: address mismatch at index {index}",
+            );
+            assert_eq!(
+                actual.in_scan, *expected_in_scan,
+                "{mode_name}: in_scan mismatch at index {index}",
+            );
+        }
     }
 }
 
@@ -412,6 +423,7 @@ fn address_should_increment_by_horizontal_displayed_per_char_line() {
 fn raster_address_odd_should_equal_even_plus_one_when_interlaced() {
     let mut registers = create_default_registers();
     registers.crtc_r8_interlace_and_skew = 0x03; // Interlace mode enabled
+    registers.crtc_r9_maximum_raster_address = 6; // 8 scanlines per field
 
     let mut crtc = setup_test(&registers);
 
@@ -628,7 +640,10 @@ fn should_show_pattern_stability_across_multiple_complete_frames() {
     let expected_scanlines = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
 
     for (index, expected) in expected_scanlines.iter().enumerate() {
-        let actual = crtc.advance_scanline(&registers).snapshot_params.scanline;
+        let actual = crtc
+            .advance_scanline(&registers)
+            .snapshot_params
+            .beam_scanline;
 
         assert_eq!(actual, *expected, "mismatch at index {index}");
     }

--- a/ch22-core/src/video/crtc/tests.rs
+++ b/ch22-core/src/video/crtc/tests.rs
@@ -399,17 +399,17 @@ fn should_respect_vertical_total_adjust_when_completing_frames() {
 }
 
 // ============================================================================
-// TRIGGER AND FREQUENCY BEHAVIOR
+// CYCLES AND FREQUENCY BEHAVIOR
 // ============================================================================
 
 #[test]
-fn should_maintain_consistent_next_scanline_trigger_in_both_frequency_modes() {
+fn should_maintain_consistent_next_scanline_cycles_in_both_frequency_modes() {
     // ula_control bit 4 selects frequency: 0=normal, 1=high
-    // Trigger = (horizontal_total + 1) * clock_divisor
+    // Cycles = (horizontal_total + 1) * clock_divisor
     // Normal mode: (127+1) * 2 = 256, High freq: (127+1) * 1 = 128
-    let frequency_test_cases = [(0x00, 256u16), (0x10, 128u16)];
+    let frequency_test_cases = [(0x00, 256u64), (0x10, 128u64)];
 
-    for (ula_control, expected_trigger) in frequency_test_cases {
+    for (ula_control, expected_cycles) in frequency_test_cases {
         let registers = VideoRegisters {
             crtc_r0_horizontal_total: 127,
             ula_control, // 0x00=normal, 0x10=high frequency
@@ -419,10 +419,10 @@ fn should_maintain_consistent_next_scanline_trigger_in_both_frequency_modes() {
         let mut crtc = Crtc::default();
         crtc.init(&registers);
 
-        let expected_triggers = [expected_trigger; 20];
+        let expected_cycles = [expected_cycles; 20];
 
-        for (index, expected) in expected_triggers.iter().enumerate() {
-            let actual = crtc.get_next_scanline_trigger(&registers);
+        for (index, expected) in expected_cycles.iter().enumerate() {
+            let actual = crtc.get_next_scanline_cycles(&registers);
 
             assert_eq!(
                 actual, *expected,
@@ -658,9 +658,9 @@ fn should_handle_horizontal_total_zero() {
     let mut crtc = Crtc::default();
     crtc.init(&registers);
 
-    let actual = crtc.get_next_scanline_trigger(&registers);
+    let actual = crtc.get_next_scanline_cycles(&registers);
 
-    // Trigger = (0 + 1) * 2 = 2
+    // cycles = (0 + 1) * 2 = 2
     assert_eq!(actual, 2);
 }
 
@@ -675,14 +675,14 @@ fn should_handle_horizontal_total_255() {
     let mut crtc = Crtc::default();
     crtc.init(&registers);
 
-    let actual = crtc.get_next_scanline_trigger(&registers);
+    let actual = crtc.get_next_scanline_cycles(&registers);
 
-    // Trigger = (255 + 1) * 1 = 256 (high freq mode uses divisor 1)
+    // cycles = (255 + 1) * 1 = 256 (high freq mode uses divisor 1)
     assert_eq!(actual, 256);
 }
 
 #[test]
-fn should_maintain_consistent_trigger_values_across_multiple_frames() {
+fn should_maintain_consistent_cycle_values_across_multiple_frames() {
     let registers = VideoRegisters {
         crtc_r0_horizontal_total: 127,
         crtc_r4_vertical_total: 2, // 3 char lines
@@ -696,11 +696,11 @@ fn should_maintain_consistent_trigger_values_across_multiple_frames() {
     crtc.init(&registers);
 
     // Frame = 3 char lines * 2 scanlines = 6 scanlines. Test 17 scanlines = 2.8 frames
-    // next_scanline_trigger should remain constant (256) throughout
-    let expected_triggers = [256u16; 17];
+    // next_scanline_cycles should remain constant (256) throughout
+    let expected_cycles = [256u64; 17];
 
-    for (index, expected) in expected_triggers.iter().enumerate() {
-        let actual = crtc.get_next_scanline_trigger(&registers);
+    for (index, expected) in expected_cycles.iter().enumerate() {
+        let actual = crtc.get_next_scanline_cycles(&registers);
 
         assert_eq!(actual, *expected, "mismatch at index {index}");
 
@@ -713,7 +713,7 @@ fn should_maintain_consistent_trigger_values_across_multiple_frames() {
 // ============================================================================
 
 #[test]
-fn should_toggle_interlace_frame_and_double_trigger_on_alternate_frames() {
+fn should_toggle_interlace_frame_and_double_cycles_on_alternate_frames() {
     let registers = VideoRegisters {
         crtc_r9_maximum_raster_address: 1,
         crtc_r4_vertical_total: 1, // 2 char lines per frame
@@ -728,13 +728,13 @@ fn should_toggle_interlace_frame_and_double_trigger_on_alternate_frames() {
 
     // Frame = 2 char lines * 2 scanlines = 4 scanlines.
     // In interlace sync mode, every 4th scanline (at char line 1 of odd frames)
-    // gets double trigger (512) for half-line offset. Pattern: 256,256,256,512,...
-    let expected_triggers = [
+    // gets double cycles (512) for half-line offset. Pattern: 256,256,256,512,...
+    let expected_cycles = [
         256, 256, 256, 256, 512, 256, 256, 256, 256, 256, 256, 256, 512, 256,
     ];
 
-    for (index, expected) in expected_triggers.iter().enumerate() {
-        let actual = crtc.get_next_scanline_trigger(&registers);
+    for (index, expected) in expected_cycles.iter().enumerate() {
+        let actual = crtc.get_next_scanline_cycles(&registers);
 
         assert_eq!(actual, *expected, "mismatch at index {index}");
 

--- a/ch22-core/src/video/crtc/tests.rs
+++ b/ch22-core/src/video/crtc/tests.rs
@@ -1,0 +1,803 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use super::{AdvanceScanlineResult, CRTC, SnapshotParams};
+use crate::video::VideoRegisters;
+
+#[derive(Default)]
+struct ExpectedSnapshot {
+    in_scan: Option<bool>,
+    scanline: Option<u16>,
+    address: Option<u16>,
+    raster_address_even: Option<u8>,
+    raster_address_odd: Option<u8>,
+}
+
+fn assert_snapshot_matches(actual: &SnapshotParams, expected: &ExpectedSnapshot) {
+    if let Some(value) = expected.in_scan {
+        assert_eq!(actual.in_scan, value, "in_scan mismatch");
+    }
+    if let Some(value) = expected.scanline {
+        assert_eq!(actual.scanline, value, "scanline mismatch");
+    }
+    if let Some(value) = expected.address {
+        assert_eq!(actual.address, value, "address mismatch");
+    }
+    if let Some(value) = expected.raster_address_even {
+        assert_eq!(actual.raster_address_even, value, "raster_address_even mismatch");
+    }
+    if let Some(value) = expected.raster_address_odd {
+        assert_eq!(actual.raster_address_odd, value, "raster_address_odd mismatch");
+    }
+}
+
+fn create_default_registers() -> VideoRegisters {
+    let mut registers = VideoRegisters::default();
+
+    registers.crtc_r0_horizontal_total = 127;
+    registers.crtc_r1_horizontal_displayed = 80;
+    registers.crtc_r3_sync_width = 0x20;
+    registers.crtc_r4_vertical_total = 24;
+    registers.crtc_r5_vertical_total_adjust = 0;
+    registers.crtc_r6_vertical_displayed = 20;
+    registers.crtc_r7_vertical_sync_position = 20;
+    registers.crtc_r8_interlace_and_skew = 0x00;
+    registers.crtc_r9_maximum_raster_address = 7;
+    registers.crtc_r12_start_address_h = 0x20;
+    registers.crtc_r13_start_address_l = 0x00;
+    registers.ula_control = 0x00;
+
+    registers
+}
+
+fn setup_test(registers: Rc<RefCell<VideoRegisters>>) -> CRTC {
+    let mut crtc = CRTC::new(registers);
+    crtc.init();
+    crtc
+}
+
+fn collect_results(crtc: &mut CRTC, iterations: usize) -> Vec<AdvanceScanlineResult> {
+    (0..iterations).map(|_| crtc.advance_scanline()).collect()
+}
+
+#[test]
+fn should_increment_scanline_by_1_on_each_call() {
+    let registers = Rc::new(RefCell::new(create_default_registers()));
+    let mut crtc = setup_test(registers);
+
+    let results = collect_results(&mut crtc, 10);
+    let scanlines: Vec<u16> = results.iter().map(|r| r.snapshot_params.scanline).collect();
+
+    let expected_scanlines: Vec<u16> = (0..10).map(|i| i as u16).collect();
+
+    assert_eq!(scanlines, expected_scanlines);
+}
+
+#[test]
+fn should_cycle_raster_address_even_pattern_after_char_scanlines_calls() {
+    let mut registers = create_default_registers();
+    registers.crtc_r9_maximum_raster_address = 7;
+    registers.crtc_r1_horizontal_displayed = 80;
+
+    let registers = Rc::new(RefCell::new(registers));
+    let mut crtc = setup_test(registers);
+
+    let results = collect_results(&mut crtc, 16);
+    let raster_pattern: Vec<u8> = results
+        .iter()
+        .map(|r| r.snapshot_params.raster_address_even)
+        .collect();
+
+    let expected_pattern: Vec<u8> = vec![0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7];
+
+    assert_eq!(raster_pattern, expected_pattern);
+}
+
+#[test]
+fn should_advance_address_by_horizontal_displayed_after_char_scanlines() {
+    let mut registers = create_default_registers();
+    registers.crtc_r9_maximum_raster_address = 7;
+    registers.crtc_r1_horizontal_displayed = 50;
+
+    let registers = Rc::new(RefCell::new(registers));
+    let mut crtc = setup_test(registers);
+
+    let results = collect_results(&mut crtc, 9);
+    let addresses: Vec<u16> = results.iter().map(|r| r.snapshot_params.address).collect();
+
+    let expected_addresses: Vec<u16> = vec![
+        0x2000, 0x2000, 0x2000, 0x2000, 0x2000, 0x2000, 0x2000, 0x2000, 0x2032,
+    ];
+
+    assert_eq!(addresses, expected_addresses);
+}
+
+#[test]
+fn should_transition_in_scan_from_true_to_false_at_display_boundary() {
+    let mut registers = create_default_registers();
+    registers.crtc_r9_maximum_raster_address = 1;
+    registers.crtc_r6_vertical_displayed = 2;
+    registers.crtc_r4_vertical_total = 10;
+
+    let registers = Rc::new(RefCell::new(registers));
+    let mut crtc = setup_test(registers);
+
+    let results = collect_results(&mut crtc, 7);
+    let in_scan_values: Vec<bool> = results.iter().map(|r| r.snapshot_params.in_scan).collect();
+
+    let expected_pattern = vec![true, true, true, true, false, false, false];
+
+    assert_eq!(in_scan_values, expected_pattern);
+}
+
+#[test]
+fn should_return_field_complete_true_at_max_lines() {
+    let mut registers = create_default_registers();
+    registers.crtc_r7_vertical_sync_position = 255;
+
+    let registers = Rc::new(RefCell::new(registers));
+    let mut crtc = setup_test(registers);
+
+    let mut field_complete_iteration: i32 = -1;
+    for i in 0..(crate::video::MAX_LINES + 10) {
+        let result = crtc.advance_scanline();
+        if result.field_complete {
+            field_complete_iteration = i as i32;
+            break;
+        }
+    }
+
+    assert_eq!(
+        field_complete_iteration,
+        crate::video::MAX_LINES as i32 - 1,
+        "field_complete should occur at iteration {}",
+        crate::video::MAX_LINES - 1
+    );
+}
+
+#[test]
+fn should_stop_incrementing_addr_after_char_line_exceeds_vertical_total() {
+    let mut registers = create_default_registers();
+    registers.crtc_r9_maximum_raster_address = 1;
+    registers.crtc_r4_vertical_total = 2;
+    registers.crtc_r1_horizontal_displayed = 50;
+    registers.crtc_r6_vertical_displayed = 2;
+    registers.crtc_r7_vertical_sync_position = 10;
+
+    let registers = Rc::new(RefCell::new(registers));
+    let mut crtc = setup_test(registers);
+
+    let results = collect_results(&mut crtc, 10);
+
+    let expected = vec![
+        ExpectedSnapshot {
+            address: Some(0x2000),
+            in_scan: Some(true),
+            scanline: Some(0),
+            raster_address_even: Some(0),
+            ..ExpectedSnapshot::default()
+        },
+        ExpectedSnapshot {
+            address: Some(0x2000),
+            in_scan: Some(true),
+            scanline: Some(1),
+            raster_address_even: Some(1),
+            ..ExpectedSnapshot::default()
+        },
+        ExpectedSnapshot {
+            address: Some(0x2032),
+            in_scan: Some(true),
+            scanline: Some(2),
+            raster_address_even: Some(0),
+            ..ExpectedSnapshot::default()
+        },
+        ExpectedSnapshot {
+            address: Some(0x2032),
+            in_scan: Some(true),
+            scanline: Some(3),
+            raster_address_even: Some(1),
+            ..ExpectedSnapshot::default()
+        },
+        ExpectedSnapshot {
+            address: Some(0x2064),
+            in_scan: Some(false),
+            scanline: Some(4),
+            raster_address_even: Some(0),
+            ..ExpectedSnapshot::default()
+        },
+        ExpectedSnapshot {
+            address: Some(0x2064),
+            in_scan: Some(false),
+            scanline: Some(5),
+            raster_address_even: Some(1),
+            ..ExpectedSnapshot::default()
+        },
+        ExpectedSnapshot {
+            address: Some(0x2000),
+            in_scan: Some(true),
+            scanline: Some(6),
+            raster_address_even: Some(0),
+            ..ExpectedSnapshot::default()
+        },
+        ExpectedSnapshot {
+            address: Some(0x2000),
+            in_scan: Some(true),
+            scanline: Some(7),
+            raster_address_even: Some(1),
+            ..ExpectedSnapshot::default()
+        },
+        ExpectedSnapshot {
+            address: Some(0x2032),
+            in_scan: Some(true),
+            scanline: Some(8),
+            raster_address_even: Some(0),
+            ..ExpectedSnapshot::default()
+        },
+        ExpectedSnapshot {
+            address: Some(0x2032),
+            in_scan: Some(true),
+            scanline: Some(9),
+            raster_address_even: Some(1),
+            ..ExpectedSnapshot::default()
+        },
+    ];
+
+    for (actual, expected) in results.iter().zip(expected.iter()) {
+        assert_snapshot_matches(&actual.snapshot_params, expected);
+    }
+}
+
+#[test]
+fn should_maintain_consistent_scanline_delta() {
+    let registers = Rc::new(RefCell::new(create_default_registers()));
+    let mut crtc = setup_test(registers);
+
+    let results = collect_results(&mut crtc, 50);
+    let scanlines: Vec<u16> = results.iter().map(|r| r.snapshot_params.scanline).collect();
+
+    let expected_scanlines: Vec<u16> = (0..50).map(|i| i as u16).collect();
+
+    assert_eq!(scanlines, expected_scanlines);
+}
+
+#[test]
+fn should_track_raster_address_progression_correctly() {
+    let mut registers = create_default_registers();
+    registers.crtc_r9_maximum_raster_address = 3;
+    registers.crtc_r8_interlace_and_skew = 0x00;
+
+    let registers = Rc::new(RefCell::new(registers));
+    let mut crtc = setup_test(registers);
+
+    let results = collect_results(&mut crtc, 12);
+    let raster_addresses: Vec<u8> = results
+        .iter()
+        .map(|r| r.snapshot_params.raster_address_even)
+        .collect();
+
+    let expected_pattern: Vec<u8> = vec![0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3];
+
+    assert_eq!(raster_addresses, expected_pattern);
+}
+
+#[test]
+fn should_trigger_vsync_at_correct_positions() {
+    let test_cases = vec![
+        (1, 0x00, vec![], 10),
+        (2, 0x10, vec![4], 15),
+        (2, 0x20, vec![4, 5], 20),
+        (3, 0x20, vec![6, 7], 20),
+        (2, 0x30, vec![4, 5, 6], 20),
+        (2, 0x40, vec![4, 5, 6, 7], 15),
+    ];
+
+    for (r7_vertical_sync_position, r3_sync_width, expected_indices, length) in test_cases {
+        let mut registers = create_default_registers();
+        registers.crtc_r9_maximum_raster_address = 1;
+        registers.crtc_r7_vertical_sync_position = r7_vertical_sync_position;
+        registers.crtc_r3_sync_width = r3_sync_width;
+        registers.crtc_r4_vertical_total = 10;
+
+        let registers = Rc::new(RefCell::new(registers));
+        let mut crtc = setup_test(registers);
+
+        let results = collect_results(&mut crtc, length);
+        let vsync_values: Vec<bool> = results.iter().map(|r| r.vsync).collect();
+
+        let expected: Vec<bool> = (0..length)
+            .map(|i| expected_indices.contains(&i))
+            .collect();
+
+        assert_eq!(vsync_values, expected);
+    }
+}
+
+#[test]
+fn should_complete_frame_at_correct_boundary() {
+    let mut registers = create_default_registers();
+    registers.crtc_r9_maximum_raster_address = 1;
+    registers.crtc_r4_vertical_total = 2;
+    registers.crtc_r5_vertical_total_adjust = 0;
+
+    let registers = Rc::new(RefCell::new(registers));
+    let mut crtc = setup_test(registers);
+
+    let results = collect_results(&mut crtc, 8);
+    let addresses: Vec<u16> = results.iter().map(|r| r.snapshot_params.address).collect();
+    let start_address = addresses[0];
+
+    let mut reset_iteration: i32 = -1;
+    for i in 1..addresses.len() {
+        if addresses[i] == start_address && i > 4 {
+            reset_iteration = i as i32;
+            break;
+        }
+    }
+
+    assert_eq!(reset_iteration, 6, "Address should reset at iteration 6");
+}
+
+#[test]
+fn should_reset_scanline_after_field_complete() {
+    let registers = Rc::new(RefCell::new(create_default_registers()));
+    let mut crtc = setup_test(registers);
+
+    let results = collect_results(&mut crtc, 165);
+
+    let mut field_complete_index: i32 = -1;
+    for (i, result) in results.iter().enumerate() {
+        if result.field_complete {
+            field_complete_index = i as i32;
+            break;
+        }
+    }
+
+    assert_eq!(field_complete_index, 160);
+
+    let scanline_at_field_complete = results[field_complete_index as usize]
+        .snapshot_params
+        .scanline;
+    assert_eq!(scanline_at_field_complete, 160);
+
+    let scanline_after_reset = results[field_complete_index as usize + 1]
+        .snapshot_params
+        .scanline;
+    assert_eq!(scanline_after_reset, 0);
+}
+
+#[test]
+fn should_respect_vertical_total_adjust_when_completing_frames() {
+    let mut registers = create_default_registers();
+    registers.crtc_r9_maximum_raster_address = 1;
+    registers.crtc_r4_vertical_total = 2;
+    registers.crtc_r5_vertical_total_adjust = 3;
+    registers.crtc_r1_horizontal_displayed = 50;
+    registers.crtc_r6_vertical_displayed = 2;
+    registers.crtc_r7_vertical_sync_position = 0;
+
+    let registers = Rc::new(RefCell::new(registers));
+    let mut crtc = setup_test(registers);
+
+    let results = collect_results(&mut crtc, 12);
+
+    let expected = vec![
+        ExpectedSnapshot {
+            address: Some(0x2000),
+            in_scan: Some(true),
+            ..ExpectedSnapshot::default()
+        },
+        ExpectedSnapshot {
+            address: Some(0x2000),
+            in_scan: Some(true),
+            ..ExpectedSnapshot::default()
+        },
+        ExpectedSnapshot {
+            address: Some(0x2032),
+            in_scan: Some(true),
+            ..ExpectedSnapshot::default()
+        },
+        ExpectedSnapshot {
+            address: Some(0x2032),
+            in_scan: Some(true),
+            ..ExpectedSnapshot::default()
+        },
+        ExpectedSnapshot {
+            address: Some(0x2064),
+            in_scan: Some(false),
+            ..ExpectedSnapshot::default()
+        },
+        ExpectedSnapshot {
+            address: Some(0x2064),
+            in_scan: Some(false),
+            ..ExpectedSnapshot::default()
+        },
+        ExpectedSnapshot {
+            address: Some(0x2096),
+            in_scan: Some(false),
+            ..ExpectedSnapshot::default()
+        },
+        ExpectedSnapshot {
+            address: Some(0x2096),
+            in_scan: Some(false),
+            ..ExpectedSnapshot::default()
+        },
+        ExpectedSnapshot {
+            address: Some(0x2096),
+            in_scan: Some(false),
+            ..ExpectedSnapshot::default()
+        },
+        ExpectedSnapshot {
+            address: Some(0x2000),
+            in_scan: Some(true),
+            ..ExpectedSnapshot::default()
+        },
+        ExpectedSnapshot {
+            address: Some(0x2000),
+            in_scan: Some(true),
+            ..ExpectedSnapshot::default()
+        },
+    ];
+
+    for (actual, expected) in results.iter().zip(expected.iter()) {
+        assert_snapshot_matches(&actual.snapshot_params, expected);
+    }
+}
+
+#[test]
+fn should_maintain_consistent_next_scanline_trigger_in_both_frequency_modes() {
+    let test_cases = vec![(0x00, 256u16), (0x10, 128u16)];
+
+    for (ula_control, expected_trigger) in test_cases {
+        let mut registers = create_default_registers();
+        registers.crtc_r0_horizontal_total = 127;
+        registers.ula_control = ula_control;
+
+        let registers = Rc::new(RefCell::new(registers));
+        let mut crtc = setup_test(registers);
+
+        let results = collect_results(&mut crtc, 20);
+        let triggers: Vec<u16> = results.iter().map(|r| r.next_scanline_trigger).collect();
+        let expected_triggers = vec![expected_trigger; 20];
+
+        assert_eq!(triggers, expected_triggers);
+    }
+}
+
+#[test]
+fn field_complete_should_only_occur_at_boundaries() {
+    let registers = Rc::new(RefCell::new(create_default_registers()));
+    let mut crtc = setup_test(registers);
+
+    let results = collect_results(&mut crtc, 165);
+
+    let field_complete_indices: Vec<usize> = results
+        .iter()
+        .enumerate()
+        .filter_map(|(i, r)| if r.field_complete { Some(i) } else { None })
+        .collect();
+
+    assert_eq!(field_complete_indices.len(), 1);
+    assert_eq!(field_complete_indices[0], 160);
+}
+
+#[test]
+fn address_should_increment_by_horizontal_displayed_per_char_line() {
+    let mut registers = create_default_registers();
+    registers.crtc_r1_horizontal_displayed = 40;
+    registers.crtc_r9_maximum_raster_address = 1;
+    registers.crtc_r4_vertical_total = 10;
+
+    let registers = Rc::new(RefCell::new(registers));
+    let mut crtc = setup_test(registers);
+
+    let results = collect_results(&mut crtc, 6);
+    let addresses: Vec<u16> = results.iter().map(|r| r.snapshot_params.address).collect();
+
+    let expected_addresses: Vec<u16> = vec![0x2000, 0x2000, 0x2028, 0x2028, 0x2050, 0x2050];
+
+    assert_eq!(addresses, expected_addresses);
+}
+
+#[test]
+fn raster_address_odd_should_equal_even_plus_one_when_interlaced() {
+    let mut registers = create_default_registers();
+    registers.crtc_r8_interlace_and_skew = 0x03;
+
+    let registers = Rc::new(RefCell::new(registers));
+    let mut crtc = setup_test(registers);
+
+    let results = collect_results(&mut crtc, 10);
+
+    let expected = vec![
+        ExpectedSnapshot {
+            raster_address_even: Some(0),
+            raster_address_odd: Some(1),
+            ..ExpectedSnapshot::default()
+        },
+        ExpectedSnapshot {
+            raster_address_even: Some(2),
+            raster_address_odd: Some(3),
+            ..ExpectedSnapshot::default()
+        },
+        ExpectedSnapshot {
+            raster_address_even: Some(4),
+            raster_address_odd: Some(5),
+            ..ExpectedSnapshot::default()
+        },
+        ExpectedSnapshot {
+            raster_address_even: Some(6),
+            raster_address_odd: Some(7),
+            ..ExpectedSnapshot::default()
+        },
+        ExpectedSnapshot {
+            raster_address_even: Some(0),
+            raster_address_odd: Some(1),
+            ..ExpectedSnapshot::default()
+        },
+        ExpectedSnapshot {
+            raster_address_even: Some(2),
+            raster_address_odd: Some(3),
+            ..ExpectedSnapshot::default()
+        },
+        ExpectedSnapshot {
+            raster_address_even: Some(4),
+            raster_address_odd: Some(5),
+            ..ExpectedSnapshot::default()
+        },
+        ExpectedSnapshot {
+            raster_address_even: Some(6),
+            raster_address_odd: Some(7),
+            ..ExpectedSnapshot::default()
+        },
+        ExpectedSnapshot {
+            raster_address_even: Some(0),
+            raster_address_odd: Some(1),
+            ..ExpectedSnapshot::default()
+        },
+        ExpectedSnapshot {
+            raster_address_even: Some(2),
+            raster_address_odd: Some(3),
+            ..ExpectedSnapshot::default()
+        },
+    ];
+
+    for (actual, expected) in results.iter().zip(expected.iter()) {
+        assert_snapshot_matches(&actual.snapshot_params, expected);
+    }
+}
+
+#[test]
+fn raster_address_odd_should_equal_even_when_not_interlaced() {
+    let mut registers = create_default_registers();
+    registers.crtc_r8_interlace_and_skew = 0x00;
+
+    let registers = Rc::new(RefCell::new(registers));
+    let mut crtc = setup_test(registers);
+
+    let results = collect_results(&mut crtc, 10);
+
+    let expected = vec![
+        ExpectedSnapshot {
+            raster_address_even: Some(0),
+            raster_address_odd: Some(0),
+            ..ExpectedSnapshot::default()
+        },
+        ExpectedSnapshot {
+            raster_address_even: Some(1),
+            raster_address_odd: Some(1),
+            ..ExpectedSnapshot::default()
+        },
+        ExpectedSnapshot {
+            raster_address_even: Some(2),
+            raster_address_odd: Some(2),
+            ..ExpectedSnapshot::default()
+        },
+        ExpectedSnapshot {
+            raster_address_even: Some(3),
+            raster_address_odd: Some(3),
+            ..ExpectedSnapshot::default()
+        },
+        ExpectedSnapshot {
+            raster_address_even: Some(4),
+            raster_address_odd: Some(4),
+            ..ExpectedSnapshot::default()
+        },
+        ExpectedSnapshot {
+            raster_address_even: Some(5),
+            raster_address_odd: Some(5),
+            ..ExpectedSnapshot::default()
+        },
+        ExpectedSnapshot {
+            raster_address_even: Some(6),
+            raster_address_odd: Some(6),
+            ..ExpectedSnapshot::default()
+        },
+        ExpectedSnapshot {
+            raster_address_even: Some(7),
+            raster_address_odd: Some(7),
+            ..ExpectedSnapshot::default()
+        },
+        ExpectedSnapshot {
+            raster_address_even: Some(0),
+            raster_address_odd: Some(0),
+            ..ExpectedSnapshot::default()
+        },
+        ExpectedSnapshot {
+            raster_address_even: Some(1),
+            raster_address_odd: Some(1),
+            ..ExpectedSnapshot::default()
+        },
+    ];
+
+    for (actual, expected) in results.iter().zip(expected.iter()) {
+        assert_snapshot_matches(&actual.snapshot_params, expected);
+    }
+}
+
+#[test]
+fn address_should_only_update_from_start_registers_at_frame_boundary() {
+    let mut registers = create_default_registers();
+    registers.crtc_r9_maximum_raster_address = 1;
+    registers.crtc_r4_vertical_total = 2;
+    registers.crtc_r5_vertical_total_adjust = 0;
+    registers.crtc_r1_horizontal_displayed = 50;
+    registers.crtc_r12_start_address_h = 0x20;
+    registers.crtc_r13_start_address_l = 0x00;
+    registers.crtc_r7_vertical_sync_position = 10;
+
+    let registers = Rc::new(RefCell::new(registers));
+    let mut crtc = setup_test(registers.clone());
+
+    let first_results = collect_results(&mut crtc, 8);
+    let first_addresses: Vec<u16> = first_results
+        .iter()
+        .map(|r| r.snapshot_params.address)
+        .collect();
+    assert_eq!(
+        first_addresses,
+        vec![0x2000, 0x2000, 0x2032, 0x2032, 0x2064, 0x2064, 0x2000, 0x2000]
+    );
+
+    registers.borrow_mut().crtc_r12_start_address_h = 0x30;
+    let second_results = collect_results(&mut crtc, 6);
+    let second_addresses: Vec<u16> = second_results
+        .iter()
+        .map(|r| r.snapshot_params.address)
+        .collect();
+    assert_eq!(
+        second_addresses,
+        vec![0x2032, 0x2032, 0x2064, 0x2064, 0x3000, 0x3000]
+    );
+}
+
+#[test]
+fn should_handle_scan_lines_per_char_zero() {
+    let mut registers = create_default_registers();
+    registers.crtc_r9_maximum_raster_address = 0;
+    registers.crtc_r6_vertical_displayed = 2;
+    registers.crtc_r4_vertical_total = 5;
+
+    let registers = Rc::new(RefCell::new(registers));
+    let mut crtc = setup_test(registers);
+
+    let results = collect_results(&mut crtc, 5);
+    let raster_addresses: Vec<u8> = results
+        .iter()
+        .map(|r| r.snapshot_params.raster_address_even)
+        .collect();
+
+    let expected_addresses = vec![0, 0, 0, 0, 0];
+
+    assert_eq!(raster_addresses, expected_addresses);
+}
+
+#[test]
+fn should_handle_minimal_display_area() {
+    let mut registers = create_default_registers();
+    registers.crtc_r9_maximum_raster_address = 1;
+    registers.crtc_r6_vertical_displayed = 1;
+    registers.crtc_r4_vertical_total = 5;
+
+    let registers = Rc::new(RefCell::new(registers));
+    let mut crtc = setup_test(registers);
+
+    let results = collect_results(&mut crtc, 5);
+    let in_scan_values: Vec<bool> = results.iter().map(|r| r.snapshot_params.in_scan).collect();
+
+    let expected_pattern = vec![true, true, false, false, false];
+
+    assert_eq!(in_scan_values, expected_pattern);
+}
+
+#[test]
+fn should_handle_horizontal_total_zero() {
+    let mut registers = create_default_registers();
+    registers.crtc_r0_horizontal_total = 0;
+    registers.ula_control = 0x00;
+
+    let registers = Rc::new(RefCell::new(registers));
+    let mut crtc = setup_test(registers);
+
+    let result = crtc.advance_scanline();
+
+    assert_eq!(result.next_scanline_trigger, 2);
+}
+
+#[test]
+fn should_handle_horizontal_total_255() {
+    let mut registers = create_default_registers();
+    registers.crtc_r0_horizontal_total = 255;
+    registers.ula_control = 0x10;
+
+    let registers = Rc::new(RefCell::new(registers));
+    let mut crtc = setup_test(registers);
+
+    let result = crtc.advance_scanline();
+
+    assert_eq!(result.next_scanline_trigger, 256);
+}
+
+#[test]
+fn should_maintain_consistent_trigger_values_across_multiple_frames() {
+    let mut registers = create_default_registers();
+    registers.crtc_r0_horizontal_total = 127;
+    registers.ula_control = 0x00;
+    registers.crtc_r9_maximum_raster_address = 1;
+    registers.crtc_r4_vertical_total = 2;
+    registers.crtc_r5_vertical_total_adjust = 0;
+
+    let registers = Rc::new(RefCell::new(registers));
+    let mut crtc = setup_test(registers);
+
+    let frame_length = 3 * 2;
+    let results = collect_results(&mut crtc, frame_length * 2 + 5);
+    let triggers: Vec<u16> = results.iter().map(|r| r.next_scanline_trigger).collect();
+
+    let expected_triggers = vec![256u16; 17];
+
+    assert_eq!(triggers, expected_triggers);
+}
+
+#[test]
+fn should_show_pattern_stability_across_multiple_complete_frames() {
+    let mut registers = create_default_registers();
+    registers.crtc_r9_maximum_raster_address = 1;
+    registers.crtc_r4_vertical_total = 2;
+    registers.crtc_r5_vertical_total_adjust = 0;
+    registers.crtc_r1_horizontal_displayed = 50;
+
+    let registers = Rc::new(RefCell::new(registers));
+    let mut crtc = setup_test(registers);
+
+    let frame_length = 3 * 2;
+    let results = collect_results(&mut crtc, frame_length * 3);
+    let scanlines: Vec<u16> = results.iter().map(|r| r.snapshot_params.scanline).collect();
+
+    let expected_scanlines: Vec<u16> = (0..18).map(|i| i as u16).collect();
+
+    assert_eq!(scanlines, expected_scanlines);
+}
+
+#[test]
+fn should_toggle_interlace_frame_and_double_trigger_on_alternate_frames() {
+    let mut registers = create_default_registers();
+    registers.crtc_r9_maximum_raster_address = 1;
+    registers.crtc_r4_vertical_total = 1;
+    registers.crtc_r5_vertical_total_adjust = 0;
+    registers.crtc_r0_horizontal_total = 127;
+    registers.ula_control = 0x00;
+    registers.crtc_r8_interlace_and_skew = 0x01;
+    registers.crtc_r7_vertical_sync_position = 0;
+
+    let registers = Rc::new(RefCell::new(registers));
+    let mut crtc = setup_test(registers);
+
+    let results = collect_results(&mut crtc, 13);
+    let triggers: Vec<u16> = results.iter().map(|r| r.next_scanline_trigger).collect();
+
+    let expected_triggers: Vec<u16> = vec![
+        256, 256, 256, 512, 256, 256, 256, 256, 256, 256, 256, 512, 256,
+    ];
+
+    assert_eq!(triggers, expected_triggers);
+}

--- a/ch22-core/src/video/crtc/tests.rs
+++ b/ch22-core/src/video/crtc/tests.rs
@@ -1,27 +1,26 @@
-use super::CRTC;
+use super::Crtc;
 use crate::video::VideoRegisters;
 
 fn create_default_registers() -> VideoRegisters {
-    let mut registers = VideoRegisters::default();
-
-    registers.crtc_r0_horizontal_total = 127;
-    registers.crtc_r1_horizontal_displayed = 80;
-    registers.crtc_r3_sync_width = 0x20;
-    registers.crtc_r4_vertical_total = 24;
-    registers.crtc_r5_vertical_total_adjust = 0;
-    registers.crtc_r6_vertical_displayed = 20;
-    registers.crtc_r7_vertical_sync_position = 20;
-    registers.crtc_r8_interlace_and_skew = 0x00;
-    registers.crtc_r9_maximum_raster_address = 7;
-    registers.crtc_r12_start_address_h = 0x20;
-    registers.crtc_r13_start_address_l = 0x00;
-    registers.ula_control = 0x00;
-
-    registers
+    VideoRegisters {
+        crtc_r0_horizontal_total: 127,
+        crtc_r1_horizontal_displayed: 80,
+        crtc_r3_sync_width: 0x20,
+        crtc_r4_vertical_total: 24,
+        crtc_r5_vertical_total_adjust: 0,
+        crtc_r6_vertical_displayed: 20,
+        crtc_r7_vertical_sync_position: 20,
+        crtc_r8_interlace_and_skew: 0x00,
+        crtc_r9_maximum_raster_address: 7,
+        crtc_r12_start_address_h: 0x20,
+        crtc_r13_start_address_l: 0x00,
+        ula_control: 0x00,
+        ..Default::default()
+    }
 }
 
-fn setup_test(registers: &VideoRegisters) -> CRTC {
-    let mut crtc = CRTC::default();
+fn setup_test(registers: &VideoRegisters) -> Crtc {
+    let mut crtc = Crtc::default();
     crtc.init(registers);
     crtc
 }

--- a/ch22-core/src/video/crtc/tests.rs
+++ b/ch22-core/src/video/crtc/tests.rs
@@ -1,6 +1,3 @@
-use std::cell::RefCell;
-use std::rc::Rc;
-
 use super::CRTC;
 use crate::video::VideoRegisters;
 
@@ -23,21 +20,21 @@ fn create_default_registers() -> VideoRegisters {
     registers
 }
 
-fn setup_test(registers: Rc<RefCell<VideoRegisters>>) -> CRTC {
-    let mut crtc = CRTC::new(registers);
-    crtc.init();
+fn setup_test(registers: &VideoRegisters) -> CRTC {
+    let mut crtc = CRTC::default();
+    crtc.init(registers);
     crtc
 }
 
 #[test]
 fn should_increment_scanline_by_1_on_each_call() {
-    let registers = Rc::new(RefCell::new(create_default_registers()));
-    let mut crtc = setup_test(registers);
+    let registers = create_default_registers();
+    let mut crtc = setup_test(&registers);
 
     let expected_scanlines: [u16; 10] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
 
     for (index, expected) in expected_scanlines.iter().enumerate() {
-        let actual = crtc.advance_scanline().snapshot_params.scanline;
+        let actual = crtc.advance_scanline(&registers).snapshot_params.scanline;
 
         assert_eq!(actual, *expected, "mismatch at index {index}");
     }
@@ -49,13 +46,15 @@ fn should_cycle_raster_address_even_pattern_after_char_scanlines_calls() {
     registers.crtc_r9_maximum_raster_address = 7;
     registers.crtc_r1_horizontal_displayed = 80;
 
-    let registers = Rc::new(RefCell::new(registers));
-    let mut crtc = setup_test(registers);
+    let mut crtc = setup_test(&registers);
 
     let expected_pattern = [0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7];
 
     for (index, expected) in expected_pattern.iter().enumerate() {
-        let actual = crtc.advance_scanline().snapshot_params.raster_address_even;
+        let actual = crtc
+            .advance_scanline(&registers)
+            .snapshot_params
+            .raster_address_even;
 
         assert_eq!(actual, *expected, "mismatch at index {index}");
     }
@@ -67,8 +66,7 @@ fn should_advance_address_by_horizontal_displayed_after_char_scanlines() {
     registers.crtc_r9_maximum_raster_address = 7; // 8 scanlines per character line (0-7)
     registers.crtc_r1_horizontal_displayed = 50; // 0x32 in hex
 
-    let registers = Rc::new(RefCell::new(registers));
-    let mut crtc = setup_test(registers);
+    let mut crtc = setup_test(&registers);
 
     // Address stays at 0x2000 for all 8 scanlines of first character line,
     // then advances by horizontal_displayed (0x32) to 0x2032 on scanline 8
@@ -77,7 +75,7 @@ fn should_advance_address_by_horizontal_displayed_after_char_scanlines() {
     ];
 
     for (index, expected) in expected_addresses.iter().enumerate() {
-        let actual = crtc.advance_scanline().snapshot_params.address;
+        let actual = crtc.advance_scanline(&registers).snapshot_params.address;
 
         assert_eq!(actual, *expected, "mismatch at index {index}");
     }
@@ -90,14 +88,13 @@ fn should_transition_in_scan_from_true_to_false_at_display_boundary() {
     registers.crtc_r6_vertical_displayed = 2; // 2 character lines displayed
     registers.crtc_r4_vertical_total = 10;
 
-    let registers = Rc::new(RefCell::new(registers));
-    let mut crtc = setup_test(registers);
+    let mut crtc = setup_test(&registers);
 
     // in_scan is true for 2 char lines * 2 scanlines = 4 scanlines, then false
     let expected_pattern = [true, true, true, true, false, false, false];
 
     for (index, expected) in expected_pattern.iter().enumerate() {
-        let actual = crtc.advance_scanline().snapshot_params.in_scan;
+        let actual = crtc.advance_scanline(&registers).snapshot_params.in_scan;
 
         assert_eq!(actual, *expected, "mismatch at index {index}");
     }
@@ -110,12 +107,11 @@ fn should_return_field_complete_true_at_max_lines() {
     // forcing the hardware limit (MAX_LINES) to trigger instead
     registers.crtc_r7_vertical_sync_position = 255;
 
-    let registers = Rc::new(RefCell::new(registers));
-    let mut crtc = setup_test(registers);
+    let mut crtc = setup_test(&registers);
 
     let mut field_complete_iteration: i32 = -1;
     for i in 0..(crate::video::MAX_LINES + 10) {
-        let result = crtc.advance_scanline();
+        let result = crtc.advance_scanline(&registers);
         if result.field_complete {
             field_complete_iteration = i as i32;
             break;
@@ -138,8 +134,7 @@ fn should_stop_incrementing_addr_after_char_line_exceeds_vertical_total() {
     registers.crtc_r6_vertical_displayed = 2; // 2 character lines visible
     registers.crtc_r7_vertical_sync_position = 10;
 
-    let registers = Rc::new(RefCell::new(registers));
-    let mut crtc = setup_test(registers);
+    let mut crtc = setup_test(&registers);
 
     // After char line 2 exceeds vertical_total (2), address remains at 0x2064
     // until frame resets at scanline 6, then pattern repeats
@@ -160,7 +155,7 @@ fn should_stop_incrementing_addr_after_char_line_exceeds_vertical_total() {
     for (index, (expected_address, expected_in_scan, expected_scanline, expected_raster)) in
         expected.iter().enumerate()
     {
-        let actual = crtc.advance_scanline().snapshot_params;
+        let actual = crtc.advance_scanline(&registers).snapshot_params;
 
         assert_eq!(
             actual.address, *expected_address,
@@ -183,13 +178,13 @@ fn should_stop_incrementing_addr_after_char_line_exceeds_vertical_total() {
 
 #[test]
 fn should_maintain_consistent_scanline_delta() {
-    let registers = Rc::new(RefCell::new(create_default_registers()));
-    let mut crtc = setup_test(registers);
+    let registers = create_default_registers();
+    let mut crtc = setup_test(&registers);
 
     let expected_scanlines: Vec<u16> = (0..50).map(|i| i as u16).collect();
 
     for (index, expected) in expected_scanlines.iter().enumerate() {
-        let actual = crtc.advance_scanline().snapshot_params.scanline;
+        let actual = crtc.advance_scanline(&registers).snapshot_params.scanline;
 
         assert_eq!(actual, *expected, "mismatch at index {index}");
     }
@@ -201,13 +196,15 @@ fn should_track_raster_address_progression_correctly() {
     registers.crtc_r9_maximum_raster_address = 3;
     registers.crtc_r8_interlace_and_skew = 0x00;
 
-    let registers = Rc::new(RefCell::new(registers));
-    let mut crtc = setup_test(registers);
+    let mut crtc = setup_test(&registers);
 
     let expected_pattern = [0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3];
 
     for (index, expected) in expected_pattern.iter().enumerate() {
-        let actual = crtc.advance_scanline().snapshot_params.raster_address_even;
+        let actual = crtc
+            .advance_scanline(&registers)
+            .snapshot_params
+            .raster_address_even;
 
         assert_eq!(actual, *expected, "mismatch at index {index}");
     }
@@ -235,11 +232,10 @@ fn should_trigger_vsync_at_correct_positions() {
         registers.crtc_r3_sync_width = r3_sync_width;
         registers.crtc_r4_vertical_total = 10;
 
-        let registers = Rc::new(RefCell::new(registers));
-        let mut crtc = setup_test(registers);
+        let mut crtc = setup_test(&registers);
 
         for index in 0..length {
-            let actual = crtc.advance_scanline().vsync;
+            let actual = crtc.advance_scanline(&registers).vsync;
             let expected = expected_indices.contains(&index);
 
             assert_eq!(
@@ -258,8 +254,7 @@ fn should_complete_frame_at_correct_boundary() {
     registers.crtc_r4_vertical_total = 2; // 3 char lines (0-2)
     registers.crtc_r5_vertical_total_adjust = 0;
 
-    let registers = Rc::new(RefCell::new(registers));
-    let mut crtc = setup_test(registers);
+    let mut crtc = setup_test(&registers);
 
     // Frame = 3 char lines * 2 scanlines = 6 scanlines total.
     // Address increments by 0x50 (default horizontal_displayed=80) per char line.
@@ -269,7 +264,7 @@ fn should_complete_frame_at_correct_boundary() {
     ];
 
     for (index, expected) in expected_addresses.iter().enumerate() {
-        let actual = crtc.advance_scanline().snapshot_params.address;
+        let actual = crtc.advance_scanline(&registers).snapshot_params.address;
 
         assert_eq!(actual, *expected, "mismatch at index {index}");
     }
@@ -277,12 +272,12 @@ fn should_complete_frame_at_correct_boundary() {
 
 #[test]
 fn should_reset_scanline_after_field_complete() {
-    let registers = Rc::new(RefCell::new(create_default_registers()));
-    let mut crtc = setup_test(registers);
+    let registers = create_default_registers();
+    let mut crtc = setup_test(&registers);
 
     // Advance to iteration 160 where field_complete should occur
     for iteration in 0..160 {
-        let result = crtc.advance_scanline();
+        let result = crtc.advance_scanline(&registers);
         assert!(
             !result.field_complete,
             "field_complete should be false before iteration 160 ({iteration})"
@@ -290,7 +285,7 @@ fn should_reset_scanline_after_field_complete() {
     }
 
     // At iteration 160: field_complete should be true and scanline should be 160
-    let result_at_160 = crtc.advance_scanline();
+    let result_at_160 = crtc.advance_scanline(&registers);
     assert!(
         result_at_160.field_complete,
         "field_complete should be true at iteration 160"
@@ -301,7 +296,7 @@ fn should_reset_scanline_after_field_complete() {
     );
 
     // At iteration 161: scanline should reset to 0
-    let result_at_161 = crtc.advance_scanline();
+    let result_at_161 = crtc.advance_scanline(&registers);
     assert_eq!(
         result_at_161.snapshot_params.scanline, 0,
         "scanline should reset to 0 after field_complete"
@@ -318,8 +313,7 @@ fn should_respect_vertical_total_adjust_when_completing_frames() {
     registers.crtc_r6_vertical_displayed = 2;
     registers.crtc_r7_vertical_sync_position = 0;
 
-    let registers = Rc::new(RefCell::new(registers));
-    let mut crtc = setup_test(registers);
+    let mut crtc = setup_test(&registers);
 
     // Frame = (3 char lines * 2 scanlines) + 3 adjust = 9 scanlines total.
     // Address increments stop after char lines complete, but scanlines continue.
@@ -340,7 +334,7 @@ fn should_respect_vertical_total_adjust_when_completing_frames() {
     ];
 
     for (index, (expected_address, expected_in_scan)) in expected.iter().enumerate() {
-        let actual = crtc.advance_scanline().snapshot_params;
+        let actual = crtc.advance_scanline(&registers).snapshot_params;
 
         assert_eq!(
             actual.in_scan, *expected_in_scan,
@@ -365,13 +359,12 @@ fn should_maintain_consistent_next_scanline_trigger_in_both_frequency_modes() {
         registers.crtc_r0_horizontal_total = 127;
         registers.ula_control = ula_control;
 
-        let registers = Rc::new(RefCell::new(registers));
-        let mut crtc = setup_test(registers);
+        let mut crtc = setup_test(&registers);
 
         let expected_triggers = [expected_trigger; 20];
 
         for (index, expected) in expected_triggers.iter().enumerate() {
-            let actual = crtc.advance_scanline().next_scanline_trigger;
+            let actual = crtc.advance_scanline(&registers).next_scanline_trigger;
 
             assert_eq!(actual, *expected, "mismatch at index {index}");
         }
@@ -380,13 +373,13 @@ fn should_maintain_consistent_next_scanline_trigger_in_both_frequency_modes() {
 
 #[test]
 fn field_complete_should_only_occur_at_boundaries() {
-    let registers = Rc::new(RefCell::new(create_default_registers()));
-    let mut crtc = setup_test(registers);
+    let registers = create_default_registers();
+    let mut crtc = setup_test(&registers);
 
     // With default registers: 20 char lines displayed * 8 scanlines/char = 160 scanlines
     // field_complete should occur exactly once at scanline 160
     for iteration in 0..165 {
-        let actual_field_complete = crtc.advance_scanline().field_complete;
+        let actual_field_complete = crtc.advance_scanline(&registers).field_complete;
         let expected_field_complete = iteration == 160;
 
         assert_eq!(
@@ -403,14 +396,13 @@ fn address_should_increment_by_horizontal_displayed_per_char_line() {
     registers.crtc_r9_maximum_raster_address = 1; // 2 scanlines per char line
     registers.crtc_r4_vertical_total = 10;
 
-    let registers = Rc::new(RefCell::new(registers));
-    let mut crtc = setup_test(registers);
+    let mut crtc = setup_test(&registers);
 
     // Address advances by horizontal_displayed (0x28) after each char line completes
     let expected_addresses = [0x2000, 0x2000, 0x2028, 0x2028, 0x2050, 0x2050];
 
     for (index, expected) in expected_addresses.iter().enumerate() {
-        let actual = crtc.advance_scanline().snapshot_params.address;
+        let actual = crtc.advance_scanline(&registers).snapshot_params.address;
 
         assert_eq!(actual, *expected, "mismatch at index {index}");
     }
@@ -421,8 +413,7 @@ fn raster_address_odd_should_equal_even_plus_one_when_interlaced() {
     let mut registers = create_default_registers();
     registers.crtc_r8_interlace_and_skew = 0x03; // Interlace mode enabled
 
-    let registers = Rc::new(RefCell::new(registers));
-    let mut crtc = setup_test(registers);
+    let mut crtc = setup_test(&registers);
 
     // In interlace mode, odd field raster addresses are offset by +1 from even field
 
@@ -441,7 +432,7 @@ fn raster_address_odd_should_equal_even_plus_one_when_interlaced() {
     ];
 
     for (index, (expected_even, expected_odd)) in expected.iter().enumerate() {
-        let actual = crtc.advance_scanline().snapshot_params;
+        let actual = crtc.advance_scanline(&registers).snapshot_params;
 
         assert_eq!(
             actual.raster_address_even, *expected_even,
@@ -459,8 +450,7 @@ fn raster_address_odd_should_equal_even_when_not_interlaced() {
     let mut registers = create_default_registers();
     registers.crtc_r8_interlace_and_skew = 0x00;
 
-    let registers = Rc::new(RefCell::new(registers));
-    let mut crtc = setup_test(registers);
+    let mut crtc = setup_test(&registers);
 
     let expected = [
         // raster_address_even, raster_address_odd
@@ -477,7 +467,7 @@ fn raster_address_odd_should_equal_even_when_not_interlaced() {
     ];
 
     for (index, (expected_even, expected_odd)) in expected.iter().enumerate() {
-        let actual = crtc.advance_scanline().snapshot_params;
+        let actual = crtc.advance_scanline(&registers).snapshot_params;
 
         assert_eq!(
             actual.raster_address_even, *expected_even,
@@ -501,15 +491,14 @@ fn address_should_only_update_from_start_registers_at_frame_boundary() {
     registers.crtc_r13_start_address_l = 0x00;
     registers.crtc_r7_vertical_sync_position = 10;
 
-    let registers = Rc::new(RefCell::new(registers));
-    let mut crtc = setup_test(registers.clone());
+    let mut crtc = setup_test(&registers);
 
     let first_expected_addresses = [
         0x2000, 0x2000, 0x2032, 0x2032, 0x2064, 0x2064, 0x2000, 0x2000,
     ];
 
     for (index, expected) in first_expected_addresses.iter().enumerate() {
-        let actual = crtc.advance_scanline().snapshot_params.address;
+        let actual = crtc.advance_scanline(&registers).snapshot_params.address;
 
         assert_eq!(
             actual, *expected,
@@ -518,14 +507,14 @@ fn address_should_only_update_from_start_registers_at_frame_boundary() {
     }
 
     // Change start address register mid-test
-    registers.borrow_mut().crtc_r12_start_address_h = 0x30;
+    registers.crtc_r12_start_address_h = 0x30;
 
     // Start address register change takes effect only at next frame boundary.
     // Continues at 0x2032, 0x2064, then resets to new start 0x3000 at frame boundary
     let second_expected_addresses = [0x2032, 0x2032, 0x2064, 0x2064, 0x3000, 0x3000];
 
     for (index, expected) in second_expected_addresses.iter().enumerate() {
-        let actual = crtc.advance_scanline().snapshot_params.address;
+        let actual = crtc.advance_scanline(&registers).snapshot_params.address;
 
         assert_eq!(
             actual, *expected,
@@ -541,13 +530,15 @@ fn should_handle_scan_lines_per_char_zero() {
     registers.crtc_r6_vertical_displayed = 2;
     registers.crtc_r4_vertical_total = 5;
 
-    let registers = Rc::new(RefCell::new(registers));
-    let mut crtc = setup_test(registers);
+    let mut crtc = setup_test(&registers);
 
     let expected_addresses = [0, 0, 0, 0, 0];
 
     for (index, expected) in expected_addresses.iter().enumerate() {
-        let actual = crtc.advance_scanline().snapshot_params.raster_address_even;
+        let actual = crtc
+            .advance_scanline(&registers)
+            .snapshot_params
+            .raster_address_even;
 
         assert_eq!(actual, *expected, "mismatch at index {index}");
     }
@@ -560,13 +551,12 @@ fn should_handle_minimal_display_area() {
     registers.crtc_r6_vertical_displayed = 1;
     registers.crtc_r4_vertical_total = 5;
 
-    let registers = Rc::new(RefCell::new(registers));
-    let mut crtc = setup_test(registers);
+    let mut crtc = setup_test(&registers);
 
     let expected_pattern = [true, true, false, false, false];
 
     for (index, expected) in expected_pattern.iter().enumerate() {
-        let actual = crtc.advance_scanline().snapshot_params.in_scan;
+        let actual = crtc.advance_scanline(&registers).snapshot_params.in_scan;
 
         assert_eq!(actual, *expected, "mismatch at index {index}");
     }
@@ -578,10 +568,9 @@ fn should_handle_horizontal_total_zero() {
     registers.crtc_r0_horizontal_total = 0; // Edge case: minimum value
     registers.ula_control = 0x00;
 
-    let registers = Rc::new(RefCell::new(registers));
-    let mut crtc = setup_test(registers);
+    let mut crtc = setup_test(&registers);
 
-    let actual = crtc.advance_scanline();
+    let actual = crtc.advance_scanline(&registers);
 
     // Trigger = (0 + 1) * 2 = 2
     assert_eq!(actual.next_scanline_trigger, 2);
@@ -593,10 +582,9 @@ fn should_handle_horizontal_total_255() {
     registers.crtc_r0_horizontal_total = 255; // Edge case: maximum value
     registers.ula_control = 0x10; // High frequency mode
 
-    let registers = Rc::new(RefCell::new(registers));
-    let mut crtc = setup_test(registers);
+    let mut crtc = setup_test(&registers);
 
-    let actual = crtc.advance_scanline();
+    let actual = crtc.advance_scanline(&registers);
 
     // Trigger = (255 + 1) * 1 = 256 (high freq mode uses divisor 1)
     assert_eq!(actual.next_scanline_trigger, 256);
@@ -611,15 +599,14 @@ fn should_maintain_consistent_trigger_values_across_multiple_frames() {
     registers.crtc_r4_vertical_total = 2; // 3 char lines
     registers.crtc_r5_vertical_total_adjust = 0;
 
-    let registers = Rc::new(RefCell::new(registers));
-    let mut crtc = setup_test(registers);
+    let mut crtc = setup_test(&registers);
 
     // Frame = 3 char lines * 2 scanlines = 6 scanlines. Test 17 scanlines = 2.8 frames
     // next_scanline_trigger should remain constant (256) throughout
     let expected_triggers = [256u16; 17];
 
     for (index, expected) in expected_triggers.iter().enumerate() {
-        let actual = crtc.advance_scanline().next_scanline_trigger;
+        let actual = crtc.advance_scanline(&registers).next_scanline_trigger;
 
         assert_eq!(actual, *expected, "mismatch at index {index}");
     }
@@ -633,8 +620,7 @@ fn should_show_pattern_stability_across_multiple_complete_frames() {
     registers.crtc_r5_vertical_total_adjust = 0;
     registers.crtc_r1_horizontal_displayed = 50;
 
-    let registers = Rc::new(RefCell::new(registers));
-    let mut crtc = setup_test(registers);
+    let mut crtc = setup_test(&registers);
 
     // Frame = 3 char lines * 2 scanlines = 6 scanlines.
     // Test 17 scanlines = 2 complete frames + 5 scanlines into 3rd frame.
@@ -642,7 +628,7 @@ fn should_show_pattern_stability_across_multiple_complete_frames() {
     let expected_scanlines = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
 
     for (index, expected) in expected_scanlines.iter().enumerate() {
-        let actual = crtc.advance_scanline().snapshot_params.scanline;
+        let actual = crtc.advance_scanline(&registers).snapshot_params.scanline;
 
         assert_eq!(actual, *expected, "mismatch at index {index}");
     }
@@ -659,8 +645,7 @@ fn should_toggle_interlace_frame_and_double_trigger_on_alternate_frames() {
     registers.crtc_r8_interlace_and_skew = 0x01; // Interlace sync enabled
     registers.crtc_r7_vertical_sync_position = 0;
 
-    let registers = Rc::new(RefCell::new(registers));
-    let mut crtc = setup_test(registers);
+    let mut crtc = setup_test(&registers);
 
     // Frame = 2 char lines * 2 scanlines = 4 scanlines.
     // In interlace sync mode, every 4th scanline (at char line 1 of odd frames)
@@ -670,7 +655,7 @@ fn should_toggle_interlace_frame_and_double_trigger_on_alternate_frames() {
     ];
 
     for (index, expected) in expected_triggers.iter().enumerate() {
-        let actual = crtc.advance_scanline().next_scanline_trigger;
+        let actual = crtc.advance_scanline(&registers).next_scanline_trigger;
 
         assert_eq!(actual, *expected, "mismatch at index {index}");
     }

--- a/ch22-core/src/video/crtc/tests.rs
+++ b/ch22-core/src/video/crtc/tests.rs
@@ -1,31 +1,14 @@
 use super::Crtc;
 use crate::video::VideoRegisters;
 
-fn create_default_registers() -> VideoRegisters {
-    VideoRegisters {
-        crtc_r0_horizontal_total: 127,
-        crtc_r1_horizontal_displayed: 80,
-        crtc_r3_sync_width: 0x20,
-        crtc_r4_vertical_total: 24,
-        crtc_r5_vertical_total_adjust: 0,
-        crtc_r6_vertical_displayed: 20,
-        crtc_r7_vertical_sync_position: 20,
-        crtc_r8_interlace_and_skew: 0x00,
-        crtc_r9_maximum_raster_address: 7,
-        crtc_r12_start_address_h: 0x20,
-        crtc_r13_start_address_l: 0x00,
-        ula_control: 0x00,
-        ..Default::default()
-    }
-}
-
 // ============================================================================
 // BASIC SCANLINE BEHAVIOR
 // ============================================================================
 
 #[test]
 fn should_increment_scanline_by_1_on_each_call() {
-    let registers = create_default_registers();
+    let registers = VideoRegisters::default();
+
     let mut crtc = Crtc::default();
     crtc.init(&registers);
 
@@ -46,9 +29,15 @@ fn should_increment_scanline_by_1_on_each_call() {
 
 #[test]
 fn should_advance_address_by_horizontal_displayed_after_char_scanlines() {
-    let mut registers = create_default_registers();
-    registers.crtc_r9_maximum_raster_address = 7; // 8 scanlines per character line (0-7)
-    registers.crtc_r1_horizontal_displayed = 50; // 0x32 in hex
+    let registers = VideoRegisters {
+        crtc_r1_horizontal_displayed: 50, // 0x32 in hex
+        crtc_r4_vertical_total: 24,
+        crtc_r6_vertical_displayed: 20,
+        crtc_r9_maximum_raster_address: 7, // 8 scanlines per character line (0-7)
+        crtc_r12_start_address_h: 0x20,
+        crtc_r13_start_address_l: 0x00,
+        ..Default::default()
+    };
 
     let mut crtc = Crtc::default();
     crtc.init(&registers);
@@ -70,12 +59,16 @@ fn should_advance_address_by_horizontal_displayed_after_char_scanlines() {
 
 #[test]
 fn should_stop_incrementing_addr_after_char_line_exceeds_vertical_total() {
-    let mut registers = create_default_registers();
-    registers.crtc_r9_maximum_raster_address = 1; // 2 scanlines per character line
-    registers.crtc_r4_vertical_total = 2; // 3 character lines total (0-2)
-    registers.crtc_r1_horizontal_displayed = 50; // 0x32 per line
-    registers.crtc_r6_vertical_displayed = 2; // 2 character lines visible
-    registers.crtc_r7_vertical_sync_position = 10;
+    let registers = VideoRegisters {
+        crtc_r1_horizontal_displayed: 50, // 0x32 per line
+        crtc_r4_vertical_total: 2,        // 3 character lines total (0-2)
+        crtc_r6_vertical_displayed: 2,    // 2 character lines visible
+        crtc_r7_vertical_sync_position: 10,
+        crtc_r9_maximum_raster_address: 1, // 2 scanlines per character line
+        crtc_r12_start_address_h: 0x20,    // Start address 0x2000
+        crtc_r13_start_address_l: 0x00,
+        ..Default::default()
+    };
 
     let mut crtc = Crtc::default();
     crtc.init(&registers);
@@ -135,10 +128,12 @@ fn should_track_raster_address_progression_correctly() {
         (7, [0, 1, 2, 3, 4, 5, 6, 7, 0, 1]),
     ];
 
-    for (r9_value, expected_pattern) in test_cases {
-        let mut registers = create_default_registers();
-        registers.crtc_r9_maximum_raster_address = r9_value;
-        registers.crtc_r8_interlace_and_skew = 0x00;
+    for (crtc_r9_maximum_raster_address, expected_pattern) in test_cases {
+        let registers = VideoRegisters {
+            crtc_r8_interlace_and_skew: 0x00, // No interlace
+            crtc_r9_maximum_raster_address,
+            ..Default::default()
+        };
 
         let mut crtc = Crtc::default();
         crtc.init(&registers);
@@ -149,7 +144,7 @@ fn should_track_raster_address_progression_correctly() {
             assert_eq!(
                 actual, *expected,
                 "mismatch at index {index} for r9={}",
-                r9_value
+                crtc_r9_maximum_raster_address
             );
 
             crtc.advance_scanline(&registers);
@@ -176,12 +171,15 @@ fn should_trigger_vsync_at_correct_positions() {
         (2, 0x40, vec![5, 6, 7, 8], 15), // vsync at char 2 (scanline 4), width=4
     ];
 
-    for (r7_vertical_sync_position, r3_sync_width, expected_indices, length) in test_cases {
-        let mut registers = create_default_registers();
-        registers.crtc_r9_maximum_raster_address = 1;
-        registers.crtc_r7_vertical_sync_position = r7_vertical_sync_position;
-        registers.crtc_r3_sync_width = r3_sync_width;
-        registers.crtc_r4_vertical_total = 10;
+    for (crtc_r7_vertical_sync_position, crtc_r3_sync_width, expected_indices, length) in test_cases
+    {
+        let registers = VideoRegisters {
+            crtc_r3_sync_width, // Sync width (pulse length)
+            crtc_r4_vertical_total: 10,
+            crtc_r7_vertical_sync_position,    // Position of vsync
+            crtc_r9_maximum_raster_address: 1, // 2 scanlines per character line
+            ..Default::default()
+        };
 
         let mut crtc = Crtc::default();
         crtc.init(&registers);
@@ -192,8 +190,8 @@ fn should_trigger_vsync_at_correct_positions() {
 
             assert_eq!(
                 actual, expected,
-                "vsync mismatch at index {index} for r7_vertical_sync_position={}, r3_sync_width={:#04x}",
-                r7_vertical_sync_position, r3_sync_width
+                "vsync mismatch at index {index} for crtc_r7_vertical_sync_position={}, crtc_r3_sync_width={:#04x}",
+                crtc_r7_vertical_sync_position, crtc_r3_sync_width
             );
 
             crtc.advance_scanline(&registers);
@@ -207,10 +205,12 @@ fn should_trigger_vsync_at_correct_positions() {
 
 #[test]
 fn should_transition_in_scan_from_true_to_false_at_display_boundary() {
-    let mut registers = create_default_registers();
-    registers.crtc_r9_maximum_raster_address = 1; // 2 scanlines per character line
-    registers.crtc_r6_vertical_displayed = 2; // 2 character lines displayed
-    registers.crtc_r4_vertical_total = 10;
+    let registers = VideoRegisters {
+        crtc_r4_vertical_total: 10,
+        crtc_r6_vertical_displayed: 2, // 2 character lines displayed
+        crtc_r9_maximum_raster_address: 1, // 2 scanlines per character line
+        ..Default::default()
+    };
 
     let mut crtc = Crtc::default();
     crtc.init(&registers);
@@ -229,10 +229,10 @@ fn should_transition_in_scan_from_true_to_false_at_display_boundary() {
 
 #[test]
 fn should_return_beam_scanline_0_at_max_lines() {
-    let mut registers = create_default_registers();
-    // Set vsync position to max to prevent normal field completion,
-    // forcing the hardware limit (MAX_LINES) to trigger instead
-    registers.crtc_r7_vertical_sync_position = 255;
+    let registers = VideoRegisters {
+        crtc_r7_vertical_sync_position: 255, // Prevent normal field completion
+        ..Default::default()
+    };
 
     let mut crtc = Crtc::default();
     crtc.init(&registers);
@@ -261,10 +261,15 @@ fn should_return_beam_scanline_0_at_max_lines() {
 
 #[test]
 fn should_complete_frame_at_correct_boundary() {
-    let mut registers = create_default_registers();
-    registers.crtc_r9_maximum_raster_address = 1; // 2 scanlines per char line
-    registers.crtc_r4_vertical_total = 2; // 3 char lines (0-2)
-    registers.crtc_r5_vertical_total_adjust = 0;
+    let registers = VideoRegisters {
+        crtc_r1_horizontal_displayed: 80,
+        crtc_r4_vertical_total: 2, // 3 char lines (0-2)
+        crtc_r5_vertical_total_adjust: 0,
+        crtc_r9_maximum_raster_address: 1, // 2 scanlines per char line
+        crtc_r12_start_address_h: 0x20,
+        crtc_r13_start_address_l: 0x00,
+        ..Default::default()
+    };
 
     let mut crtc = Crtc::default();
     crtc.init(&registers);
@@ -291,7 +296,14 @@ fn should_complete_frame_at_correct_boundary() {
 
 #[test]
 fn should_reset_scanline_after_beam_reset() {
-    let registers = create_default_registers();
+    let registers = VideoRegisters {
+        crtc_r4_vertical_total: 24,
+        crtc_r5_vertical_total_adjust: 0,
+        crtc_r7_vertical_sync_position: 20,
+        crtc_r9_maximum_raster_address: 7, // 8 scanlines per character line
+        ..Default::default()
+    };
+
     let mut crtc = Crtc::default();
     crtc.init(&registers);
 
@@ -336,16 +348,22 @@ fn should_respect_vertical_total_adjust_when_completing_frames() {
         ("interlace sync and video", 0x03, 2),
     ];
 
-    for (mode_name, r8_interlace_and_skew, r9_maximum_raster_address) in total_adjust_cases {
-        let mut registers = create_default_registers();
-        registers.crtc_r1_horizontal_displayed = 50;
-        registers.crtc_r4_vertical_total = 2;
-        registers.crtc_r5_vertical_total_adjust = 3;
-        registers.crtc_r6_vertical_displayed = 2;
-        registers.crtc_r7_vertical_sync_position = 0;
-        registers.crtc_r8_interlace_and_skew = r8_interlace_and_skew;
-        registers.crtc_r9_maximum_raster_address = r9_maximum_raster_address;
-        registers.ula_control = 0x00;
+    for (mode_name, crtc_r8_interlace_and_skew, crtc_r9_maximum_raster_address) in
+        total_adjust_cases
+    {
+        let registers = VideoRegisters {
+            crtc_r1_horizontal_displayed: 50,
+            crtc_r4_vertical_total: 2,
+            crtc_r5_vertical_total_adjust: 3,
+            crtc_r6_vertical_displayed: 2,
+            crtc_r7_vertical_sync_position: 0,
+            crtc_r8_interlace_and_skew,     // Variable per test case
+            crtc_r9_maximum_raster_address, // Variable per test case
+            crtc_r12_start_address_h: 0x20, // Start address 0x2000
+            crtc_r13_start_address_l: 0x00,
+            ula_control: 0x00,
+            ..Default::default()
+        };
 
         let mut crtc = Crtc::default();
         crtc.init(&registers);
@@ -392,9 +410,11 @@ fn should_maintain_consistent_next_scanline_trigger_in_both_frequency_modes() {
     let frequency_test_cases = [(0x00, 256u16), (0x10, 128u16)];
 
     for (ula_control, expected_trigger) in frequency_test_cases {
-        let mut registers = create_default_registers();
-        registers.crtc_r0_horizontal_total = 127;
-        registers.ula_control = ula_control;
+        let registers = VideoRegisters {
+            crtc_r0_horizontal_total: 127,
+            ula_control, // 0x00=normal, 0x10=high frequency
+            ..Default::default()
+        };
 
         let mut crtc = Crtc::default();
         crtc.init(&registers);
@@ -417,7 +437,14 @@ fn should_maintain_consistent_next_scanline_trigger_in_both_frequency_modes() {
 
 #[test]
 fn beam_reset_should_only_occur_at_boundaries() {
-    let registers = create_default_registers();
+    let registers = VideoRegisters {
+        crtc_r4_vertical_total: 24,
+        crtc_r5_vertical_total_adjust: 0,
+        crtc_r7_vertical_sync_position: 20,
+        crtc_r9_maximum_raster_address: 7, // 8 scanlines per character line
+        ..Default::default()
+    };
+
     let mut crtc = Crtc::default();
     crtc.init(&registers);
 
@@ -438,9 +465,11 @@ fn beam_reset_should_only_occur_at_boundaries() {
 
 #[test]
 fn raster_address_odd_should_equal_even_plus_one_when_interlaced() {
-    let mut registers = create_default_registers();
-    registers.crtc_r8_interlace_and_skew = 0x03; // Interlace mode enabled
-    registers.crtc_r9_maximum_raster_address = 6; // 8 scanlines per field
+    let registers = VideoRegisters {
+        crtc_r8_interlace_and_skew: 0x03,  // Interlace mode enabled
+        crtc_r9_maximum_raster_address: 6, // 8 scanlines per field
+        ..Default::default()
+    };
 
     let mut crtc = Crtc::default();
     crtc.init(&registers);
@@ -479,8 +508,11 @@ fn raster_address_odd_should_equal_even_plus_one_when_interlaced() {
 
 #[test]
 fn raster_address_odd_should_equal_even_when_not_interlaced() {
-    let mut registers = create_default_registers();
-    registers.crtc_r8_interlace_and_skew = 0x00;
+    let registers = VideoRegisters {
+        crtc_r8_interlace_and_skew: 0x00,
+        crtc_r9_maximum_raster_address: 7, // Default 8 scanlines per char
+        ..Default::default()
+    };
 
     let mut crtc = Crtc::default();
     crtc.init(&registers);
@@ -517,14 +549,16 @@ fn raster_address_odd_should_equal_even_when_not_interlaced() {
 
 #[test]
 fn address_should_only_update_from_start_registers_at_frame_boundary() {
-    let mut registers = create_default_registers();
-    registers.crtc_r9_maximum_raster_address = 1;
-    registers.crtc_r4_vertical_total = 2;
-    registers.crtc_r5_vertical_total_adjust = 0;
-    registers.crtc_r1_horizontal_displayed = 50;
-    registers.crtc_r12_start_address_h = 0x20;
-    registers.crtc_r13_start_address_l = 0x00;
-    registers.crtc_r7_vertical_sync_position = 10;
+    let mut registers = VideoRegisters {
+        crtc_r1_horizontal_displayed: 50,
+        crtc_r4_vertical_total: 2,
+        crtc_r5_vertical_total_adjust: 0,
+        crtc_r7_vertical_sync_position: 10,
+        crtc_r9_maximum_raster_address: 1,
+        crtc_r12_start_address_h: 0x20,
+        crtc_r13_start_address_l: 0x00,
+        ..Default::default()
+    };
 
     let mut crtc = Crtc::default();
     crtc.init(&registers);
@@ -569,10 +603,12 @@ fn address_should_only_update_from_start_registers_at_frame_boundary() {
 
 #[test]
 fn should_handle_scan_lines_per_char_zero() {
-    let mut registers = create_default_registers();
-    registers.crtc_r9_maximum_raster_address = 0; // Edge case: 1 scanline per char
-    registers.crtc_r6_vertical_displayed = 2;
-    registers.crtc_r4_vertical_total = 5;
+    let registers = VideoRegisters {
+        crtc_r4_vertical_total: 5,
+        crtc_r6_vertical_displayed: 2,
+        crtc_r9_maximum_raster_address: 0, // Edge case: 1 scanline per char
+        ..Default::default()
+    };
 
     let mut crtc = Crtc::default();
     crtc.init(&registers);
@@ -590,10 +626,12 @@ fn should_handle_scan_lines_per_char_zero() {
 
 #[test]
 fn should_handle_minimal_display_area() {
-    let mut registers = create_default_registers();
-    registers.crtc_r9_maximum_raster_address = 1;
-    registers.crtc_r6_vertical_displayed = 1;
-    registers.crtc_r4_vertical_total = 5;
+    let registers = VideoRegisters {
+        crtc_r4_vertical_total: 5,
+        crtc_r6_vertical_displayed: 1, // Minimal display area
+        crtc_r9_maximum_raster_address: 1,
+        ..Default::default()
+    };
 
     let mut crtc = Crtc::default();
     crtc.init(&registers);
@@ -611,9 +649,11 @@ fn should_handle_minimal_display_area() {
 
 #[test]
 fn should_handle_horizontal_total_zero() {
-    let mut registers = create_default_registers();
-    registers.crtc_r0_horizontal_total = 0; // Edge case: minimum value
-    registers.ula_control = 0x00;
+    let registers = VideoRegisters {
+        crtc_r0_horizontal_total: 0, // Edge case: minimum value
+        ula_control: 0x00,
+        ..Default::default()
+    };
 
     let mut crtc = Crtc::default();
     crtc.init(&registers);
@@ -626,9 +666,11 @@ fn should_handle_horizontal_total_zero() {
 
 #[test]
 fn should_handle_horizontal_total_255() {
-    let mut registers = create_default_registers();
-    registers.crtc_r0_horizontal_total = 255; // Edge case: maximum value
-    registers.ula_control = 0x10; // High frequency mode
+    let registers = VideoRegisters {
+        crtc_r0_horizontal_total: 255, // Edge case: maximum value
+        ula_control: 0x10,             // High frequency mode
+        ..Default::default()
+    };
 
     let mut crtc = Crtc::default();
     crtc.init(&registers);
@@ -641,12 +683,14 @@ fn should_handle_horizontal_total_255() {
 
 #[test]
 fn should_maintain_consistent_trigger_values_across_multiple_frames() {
-    let mut registers = create_default_registers();
-    registers.crtc_r0_horizontal_total = 127;
-    registers.ula_control = 0x00;
-    registers.crtc_r9_maximum_raster_address = 1; // 2 scanlines per char
-    registers.crtc_r4_vertical_total = 2; // 3 char lines
-    registers.crtc_r5_vertical_total_adjust = 0;
+    let registers = VideoRegisters {
+        crtc_r0_horizontal_total: 127,
+        crtc_r4_vertical_total: 2, // 3 char lines
+        crtc_r5_vertical_total_adjust: 0,
+        crtc_r9_maximum_raster_address: 1, // 2 scanlines per char
+        ula_control: 0x00,
+        ..Default::default()
+    };
 
     let mut crtc = Crtc::default();
     crtc.init(&registers);
@@ -670,14 +714,14 @@ fn should_maintain_consistent_trigger_values_across_multiple_frames() {
 
 #[test]
 fn should_toggle_interlace_frame_and_double_trigger_on_alternate_frames() {
-    let mut registers = create_default_registers();
-    registers.crtc_r9_maximum_raster_address = 1;
-    registers.crtc_r4_vertical_total = 1; // 2 char lines per frame
-    registers.crtc_r5_vertical_total_adjust = 0;
-    registers.crtc_r0_horizontal_total = 127;
-    registers.ula_control = 0x00;
-    registers.crtc_r8_interlace_and_skew = 0x01; // Interlace sync enabled
-    registers.crtc_r7_vertical_sync_position = 0;
+    let registers = VideoRegisters {
+        crtc_r9_maximum_raster_address: 1,
+        crtc_r4_vertical_total: 1, // 2 char lines per frame
+        crtc_r5_vertical_total_adjust: 0,
+        crtc_r0_horizontal_total: 127,
+        crtc_r8_interlace_and_skew: 0x01, // Interlace sync enabled
+        ..Default::default()
+    };
 
     let mut crtc = Crtc::default();
     crtc.init(&registers);

--- a/ch22-core/src/video/crtc/tests.rs
+++ b/ch22-core/src/video/crtc/tests.rs
@@ -19,16 +19,11 @@ fn create_default_registers() -> VideoRegisters {
     }
 }
 
-fn setup_test(registers: &VideoRegisters) -> Crtc {
-    let mut crtc = Crtc::default();
-    crtc.init(registers);
-    crtc
-}
-
 #[test]
 fn should_increment_scanline_by_1_on_each_call() {
     let registers = create_default_registers();
-    let mut crtc = setup_test(&registers);
+    let mut crtc = Crtc::default();
+    crtc.init(&registers);
 
     let expected_scanlines: [u16; 10] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
 
@@ -47,7 +42,8 @@ fn should_cycle_raster_address_even_pattern_after_char_scanlines_calls() {
     registers.crtc_r9_maximum_raster_address = 7;
     registers.crtc_r1_horizontal_displayed = 80;
 
-    let mut crtc = setup_test(&registers);
+    let mut crtc = Crtc::default();
+    crtc.init(&registers);
 
     let expected_pattern = [0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7];
 
@@ -66,7 +62,8 @@ fn should_advance_address_by_horizontal_displayed_after_char_scanlines() {
     registers.crtc_r9_maximum_raster_address = 7; // 8 scanlines per character line (0-7)
     registers.crtc_r1_horizontal_displayed = 50; // 0x32 in hex
 
-    let mut crtc = setup_test(&registers);
+    let mut crtc = Crtc::default();
+    crtc.init(&registers);
 
     // Address stays at 0x2000 for all 8 scanlines of first character line,
     // then advances by horizontal_displayed (0x32) to 0x2032 on scanline 8
@@ -90,7 +87,8 @@ fn should_transition_in_scan_from_true_to_false_at_display_boundary() {
     registers.crtc_r6_vertical_displayed = 2; // 2 character lines displayed
     registers.crtc_r4_vertical_total = 10;
 
-    let mut crtc = setup_test(&registers);
+    let mut crtc = Crtc::default();
+    crtc.init(&registers);
 
     // in_scan is true for 2 char lines * 2 scanlines = 4 scanlines, then false
     let expected_pattern = [true, true, true, true, false, false, false];
@@ -111,7 +109,8 @@ fn should_return_beam_scanline_0_at_max_lines() {
     // forcing the hardware limit (MAX_LINES) to trigger instead
     registers.crtc_r7_vertical_sync_position = 255;
 
-    let mut crtc = setup_test(&registers);
+    let mut crtc = Crtc::default();
+    crtc.init(&registers);
 
     // Skip iteration 0 (initial state with beam_scanline == 0)
     crtc.advance_scanline(&registers);
@@ -144,7 +143,8 @@ fn should_stop_incrementing_addr_after_char_line_exceeds_vertical_total() {
     registers.crtc_r6_vertical_displayed = 2; // 2 character lines visible
     registers.crtc_r7_vertical_sync_position = 10;
 
-    let mut crtc = setup_test(&registers);
+    let mut crtc = Crtc::default();
+    crtc.init(&registers);
 
     // After char line 2 exceeds vertical_total (2), address remains at 0x2064
     // until frame resets at scanline 6, then pattern repeats
@@ -191,7 +191,8 @@ fn should_stop_incrementing_addr_after_char_line_exceeds_vertical_total() {
 #[test]
 fn should_maintain_consistent_scanline_delta() {
     let registers = create_default_registers();
-    let mut crtc = setup_test(&registers);
+    let mut crtc = Crtc::default();
+    crtc.init(&registers);
 
     let expected_scanlines: Vec<u16> = (0..50).map(|i| i as u16).collect();
 
@@ -210,7 +211,8 @@ fn should_track_raster_address_progression_correctly() {
     registers.crtc_r9_maximum_raster_address = 3;
     registers.crtc_r8_interlace_and_skew = 0x00;
 
-    let mut crtc = setup_test(&registers);
+    let mut crtc = Crtc::default();
+    crtc.init(&registers);
 
     let expected_pattern = [0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3];
 
@@ -245,7 +247,8 @@ fn should_trigger_vsync_at_correct_positions() {
         registers.crtc_r3_sync_width = r3_sync_width;
         registers.crtc_r4_vertical_total = 10;
 
-        let mut crtc = setup_test(&registers);
+        let mut crtc = Crtc::default();
+        crtc.init(&registers);
 
         for index in 0..length {
             let actual = crtc.is_in_vsync();
@@ -269,7 +272,8 @@ fn should_complete_frame_at_correct_boundary() {
     registers.crtc_r4_vertical_total = 2; // 3 char lines (0-2)
     registers.crtc_r5_vertical_total_adjust = 0;
 
-    let mut crtc = setup_test(&registers);
+    let mut crtc = Crtc::default();
+    crtc.init(&registers);
 
     // Frame = 3 char lines * 2 scanlines = 6 scanlines total.
     // Address increments by 0x50 (default horizontal_displayed=80) per char line.
@@ -290,7 +294,8 @@ fn should_complete_frame_at_correct_boundary() {
 #[test]
 fn should_reset_scanline_after_beam_reset() {
     let registers = create_default_registers();
-    let mut crtc = setup_test(&registers);
+    let mut crtc = Crtc::default();
+    crtc.init(&registers);
 
     assert!(
         crtc.is_beam_reset(),
@@ -344,7 +349,8 @@ fn should_respect_vertical_total_adjust_when_completing_frames() {
         registers.crtc_r9_maximum_raster_address = r9_maximum_raster_address;
         registers.ula_control = 0x00;
 
-        let mut crtc = setup_test(&registers);
+        let mut crtc = Crtc::default();
+        crtc.init(&registers);
 
         let expected = [
             (0x2000, true),  // char line 0, raster 0
@@ -388,7 +394,8 @@ fn should_maintain_consistent_next_scanline_trigger_in_both_frequency_modes() {
         registers.crtc_r0_horizontal_total = 127;
         registers.ula_control = ula_control;
 
-        let mut crtc = setup_test(&registers);
+        let mut crtc = Crtc::default();
+        crtc.init(&registers);
 
         let expected_triggers = [expected_trigger; 20];
 
@@ -405,7 +412,8 @@ fn should_maintain_consistent_next_scanline_trigger_in_both_frequency_modes() {
 #[test]
 fn beam_reset_should_only_occur_at_boundaries() {
     let registers = create_default_registers();
-    let mut crtc = setup_test(&registers);
+    let mut crtc = Crtc::default();
+    crtc.init(&registers);
 
     // With default registers: 20 char lines displayed * 8 scanlines/char = 160 scanlines
     // beam_reset should occur at 0 and 161
@@ -429,7 +437,8 @@ fn address_should_increment_by_horizontal_displayed_per_char_line() {
     registers.crtc_r9_maximum_raster_address = 1; // 2 scanlines per char line
     registers.crtc_r4_vertical_total = 10;
 
-    let mut crtc = setup_test(&registers);
+    let mut crtc = Crtc::default();
+    crtc.init(&registers);
 
     // Address advances by horizontal_displayed (0x28) after each char line completes
     let expected_addresses = [0x2000, 0x2000, 0x2028, 0x2028, 0x2050, 0x2050];
@@ -449,7 +458,8 @@ fn raster_address_odd_should_equal_even_plus_one_when_interlaced() {
     registers.crtc_r8_interlace_and_skew = 0x03; // Interlace mode enabled
     registers.crtc_r9_maximum_raster_address = 6; // 8 scanlines per field
 
-    let mut crtc = setup_test(&registers);
+    let mut crtc = Crtc::default();
+    crtc.init(&registers);
 
     // In interlace mode, odd field raster addresses are offset by +1 from even field
 
@@ -488,7 +498,8 @@ fn raster_address_odd_should_equal_even_when_not_interlaced() {
     let mut registers = create_default_registers();
     registers.crtc_r8_interlace_and_skew = 0x00;
 
-    let mut crtc = setup_test(&registers);
+    let mut crtc = Crtc::default();
+    crtc.init(&registers);
 
     let expected = [
         // raster_address_even, raster_address_odd
@@ -531,7 +542,8 @@ fn address_should_only_update_from_start_registers_at_frame_boundary() {
     registers.crtc_r13_start_address_l = 0x00;
     registers.crtc_r7_vertical_sync_position = 10;
 
-    let mut crtc = setup_test(&registers);
+    let mut crtc = Crtc::default();
+    crtc.init(&registers);
 
     let first_expected_addresses = [
         0x2000, 0x2000, 0x2032, 0x2032, 0x2064, 0x2064, 0x2000, 0x2000,
@@ -574,7 +586,8 @@ fn should_handle_scan_lines_per_char_zero() {
     registers.crtc_r6_vertical_displayed = 2;
     registers.crtc_r4_vertical_total = 5;
 
-    let mut crtc = setup_test(&registers);
+    let mut crtc = Crtc::default();
+    crtc.init(&registers);
 
     let expected_addresses = [0, 0, 0, 0, 0];
 
@@ -594,7 +607,8 @@ fn should_handle_minimal_display_area() {
     registers.crtc_r6_vertical_displayed = 1;
     registers.crtc_r4_vertical_total = 5;
 
-    let mut crtc = setup_test(&registers);
+    let mut crtc = Crtc::default();
+    crtc.init(&registers);
 
     let expected_pattern = [true, true, false, false, false];
 
@@ -613,7 +627,8 @@ fn should_handle_horizontal_total_zero() {
     registers.crtc_r0_horizontal_total = 0; // Edge case: minimum value
     registers.ula_control = 0x00;
 
-    let crtc = setup_test(&registers);
+    let mut crtc = Crtc::default();
+    crtc.init(&registers);
 
     let actual = crtc.get_next_scanline_trigger(&registers);
 
@@ -627,7 +642,8 @@ fn should_handle_horizontal_total_255() {
     registers.crtc_r0_horizontal_total = 255; // Edge case: maximum value
     registers.ula_control = 0x10; // High frequency mode
 
-    let crtc = setup_test(&registers);
+    let mut crtc = Crtc::default();
+    crtc.init(&registers);
 
     let actual = crtc.get_next_scanline_trigger(&registers);
 
@@ -644,7 +660,8 @@ fn should_maintain_consistent_trigger_values_across_multiple_frames() {
     registers.crtc_r4_vertical_total = 2; // 3 char lines
     registers.crtc_r5_vertical_total_adjust = 0;
 
-    let mut crtc = setup_test(&registers);
+    let mut crtc = Crtc::default();
+    crtc.init(&registers);
 
     // Frame = 3 char lines * 2 scanlines = 6 scanlines. Test 17 scanlines = 2.8 frames
     // next_scanline_trigger should remain constant (256) throughout
@@ -667,7 +684,8 @@ fn should_show_pattern_stability_across_multiple_complete_frames() {
     registers.crtc_r5_vertical_total_adjust = 0;
     registers.crtc_r1_horizontal_displayed = 50;
 
-    let mut crtc = setup_test(&registers);
+    let mut crtc = Crtc::default();
+    crtc.init(&registers);
 
     // Frame = 3 char lines * 2 scanlines = 6 scanlines.
     // Test 17 scanlines = 2 complete frames + 5 scanlines into 3rd frame.
@@ -694,7 +712,8 @@ fn should_toggle_interlace_frame_and_double_trigger_on_alternate_frames() {
     registers.crtc_r8_interlace_and_skew = 0x01; // Interlace sync enabled
     registers.crtc_r7_vertical_sync_position = 0;
 
-    let mut crtc = setup_test(&registers);
+    let mut crtc = Crtc::default();
+    crtc.init(&registers);
 
     // Frame = 2 char lines * 2 scanlines = 4 scanlines.
     // In interlace sync mode, every 4th scanline (at char line 1 of odd frames)

--- a/ch22-core/src/video/crtc/tests.rs
+++ b/ch22-core/src/video/crtc/tests.rs
@@ -24,10 +24,16 @@ fn assert_snapshot_matches(actual: &SnapshotParams, expected: &ExpectedSnapshot)
         assert_eq!(actual.address, value, "address mismatch");
     }
     if let Some(value) = expected.raster_address_even {
-        assert_eq!(actual.raster_address_even, value, "raster_address_even mismatch");
+        assert_eq!(
+            actual.raster_address_even, value,
+            "raster_address_even mismatch"
+        );
     }
     if let Some(value) = expected.raster_address_odd {
-        assert_eq!(actual.raster_address_odd, value, "raster_address_odd mismatch");
+        assert_eq!(
+            actual.raster_address_odd, value,
+            "raster_address_odd mismatch"
+        );
     }
 }
 
@@ -304,9 +310,7 @@ fn should_trigger_vsync_at_correct_positions() {
         let results = collect_results(&mut crtc, length);
         let vsync_values: Vec<bool> = results.iter().map(|r| r.vsync).collect();
 
-        let expected: Vec<bool> = (0..length)
-            .map(|i| expected_indices.contains(&i))
-            .collect();
+        let expected: Vec<bool> = (0..length).map(|i| expected_indices.contains(&i)).collect();
 
         assert_eq!(vsync_values, expected);
     }
@@ -655,7 +659,9 @@ fn address_should_only_update_from_start_registers_at_frame_boundary() {
         .collect();
     assert_eq!(
         first_addresses,
-        vec![0x2000, 0x2000, 0x2032, 0x2032, 0x2064, 0x2064, 0x2000, 0x2000]
+        vec![
+            0x2000, 0x2000, 0x2032, 0x2032, 0x2064, 0x2064, 0x2000, 0x2000
+        ]
     );
 
     registers.borrow_mut().crtc_r12_start_address_h = 0x30;

--- a/ch22-core/src/video/crtc/tests.rs
+++ b/ch22-core/src/video/crtc/tests.rs
@@ -318,8 +318,8 @@ fn should_reset_scanline_after_beam_reset() {
     for iteration in 0..160 {
         let actual = crtc.is_beam_reset();
 
-        assert_eq!(
-            actual, false,
+        assert!(
+            !actual,
             "is_beam_reset should be false before iteration 160 ({iteration})"
         );
 
@@ -330,8 +330,8 @@ fn should_reset_scanline_after_beam_reset() {
     let snapshot_params_at_160 = crtc.get_snapshot_params(&registers);
     let beam_reset_at_160 = crtc.is_beam_reset();
 
-    assert_eq!(
-        beam_reset_at_160, true,
+    assert!(
+        beam_reset_at_160,
         "is_beam_reset should be true at iteration 160"
     );
     assert_eq!(

--- a/ch22-core/src/video/crtc/tests.rs
+++ b/ch22-core/src/video/crtc/tests.rs
@@ -1,41 +1,8 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use super::{AdvanceScanlineResult, CRTC, SnapshotParams};
+use super::CRTC;
 use crate::video::VideoRegisters;
-
-#[derive(Default)]
-struct ExpectedSnapshot {
-    in_scan: Option<bool>,
-    scanline: Option<u16>,
-    address: Option<u16>,
-    raster_address_even: Option<u8>,
-    raster_address_odd: Option<u8>,
-}
-
-fn assert_snapshot_matches(actual: &SnapshotParams, expected: &ExpectedSnapshot) {
-    if let Some(value) = expected.in_scan {
-        assert_eq!(actual.in_scan, value, "in_scan mismatch");
-    }
-    if let Some(value) = expected.scanline {
-        assert_eq!(actual.scanline, value, "scanline mismatch");
-    }
-    if let Some(value) = expected.address {
-        assert_eq!(actual.address, value, "address mismatch");
-    }
-    if let Some(value) = expected.raster_address_even {
-        assert_eq!(
-            actual.raster_address_even, value,
-            "raster_address_even mismatch"
-        );
-    }
-    if let Some(value) = expected.raster_address_odd {
-        assert_eq!(
-            actual.raster_address_odd, value,
-            "raster_address_odd mismatch"
-        );
-    }
-}
 
 fn create_default_registers() -> VideoRegisters {
     let mut registers = VideoRegisters::default();
@@ -62,21 +29,18 @@ fn setup_test(registers: Rc<RefCell<VideoRegisters>>) -> CRTC {
     crtc
 }
 
-fn collect_results(crtc: &mut CRTC, iterations: usize) -> Vec<AdvanceScanlineResult> {
-    (0..iterations).map(|_| crtc.advance_scanline()).collect()
-}
-
 #[test]
 fn should_increment_scanline_by_1_on_each_call() {
     let registers = Rc::new(RefCell::new(create_default_registers()));
     let mut crtc = setup_test(registers);
 
-    let results = collect_results(&mut crtc, 10);
-    let scanlines: Vec<u16> = results.iter().map(|r| r.snapshot_params.scanline).collect();
+    let expected_scanlines: [u16; 10] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
 
-    let expected_scanlines: Vec<u16> = (0..10).map(|i| i as u16).collect();
+    for (index, expected) in expected_scanlines.iter().enumerate() {
+        let actual = crtc.advance_scanline().snapshot_params.scanline;
 
-    assert_eq!(scanlines, expected_scanlines);
+        assert_eq!(actual, *expected, "mismatch at index {index}");
+    }
 }
 
 #[test]
@@ -88,57 +52,62 @@ fn should_cycle_raster_address_even_pattern_after_char_scanlines_calls() {
     let registers = Rc::new(RefCell::new(registers));
     let mut crtc = setup_test(registers);
 
-    let results = collect_results(&mut crtc, 16);
-    let raster_pattern: Vec<u8> = results
-        .iter()
-        .map(|r| r.snapshot_params.raster_address_even)
-        .collect();
+    let expected_pattern = [0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7];
 
-    let expected_pattern: Vec<u8> = vec![0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7];
+    for (index, expected) in expected_pattern.iter().enumerate() {
+        let actual = crtc.advance_scanline().snapshot_params.raster_address_even;
 
-    assert_eq!(raster_pattern, expected_pattern);
+        assert_eq!(actual, *expected, "mismatch at index {index}");
+    }
 }
 
 #[test]
 fn should_advance_address_by_horizontal_displayed_after_char_scanlines() {
     let mut registers = create_default_registers();
-    registers.crtc_r9_maximum_raster_address = 7;
-    registers.crtc_r1_horizontal_displayed = 50;
+    registers.crtc_r9_maximum_raster_address = 7; // 8 scanlines per character line (0-7)
+    registers.crtc_r1_horizontal_displayed = 50; // 0x32 in hex
 
     let registers = Rc::new(RefCell::new(registers));
     let mut crtc = setup_test(registers);
 
-    let results = collect_results(&mut crtc, 9);
-    let addresses: Vec<u16> = results.iter().map(|r| r.snapshot_params.address).collect();
-
-    let expected_addresses: Vec<u16> = vec![
+    // Address stays at 0x2000 for all 8 scanlines of first character line,
+    // then advances by horizontal_displayed (0x32) to 0x2032 on scanline 8
+    let expected_addresses = [
         0x2000, 0x2000, 0x2000, 0x2000, 0x2000, 0x2000, 0x2000, 0x2000, 0x2032,
     ];
 
-    assert_eq!(addresses, expected_addresses);
+    for (index, expected) in expected_addresses.iter().enumerate() {
+        let actual = crtc.advance_scanline().snapshot_params.address;
+
+        assert_eq!(actual, *expected, "mismatch at index {index}");
+    }
 }
 
 #[test]
 fn should_transition_in_scan_from_true_to_false_at_display_boundary() {
     let mut registers = create_default_registers();
-    registers.crtc_r9_maximum_raster_address = 1;
-    registers.crtc_r6_vertical_displayed = 2;
+    registers.crtc_r9_maximum_raster_address = 1; // 2 scanlines per character line
+    registers.crtc_r6_vertical_displayed = 2; // 2 character lines displayed
     registers.crtc_r4_vertical_total = 10;
 
     let registers = Rc::new(RefCell::new(registers));
     let mut crtc = setup_test(registers);
 
-    let results = collect_results(&mut crtc, 7);
-    let in_scan_values: Vec<bool> = results.iter().map(|r| r.snapshot_params.in_scan).collect();
+    // in_scan is true for 2 char lines * 2 scanlines = 4 scanlines, then false
+    let expected_pattern = [true, true, true, true, false, false, false];
 
-    let expected_pattern = vec![true, true, true, true, false, false, false];
+    for (index, expected) in expected_pattern.iter().enumerate() {
+        let actual = crtc.advance_scanline().snapshot_params.in_scan;
 
-    assert_eq!(in_scan_values, expected_pattern);
+        assert_eq!(actual, *expected, "mismatch at index {index}");
+    }
 }
 
 #[test]
 fn should_return_field_complete_true_at_max_lines() {
     let mut registers = create_default_registers();
+    // Set vsync position to max to prevent normal field completion,
+    // forcing the hardware limit (MAX_LINES) to trigger instead
     registers.crtc_r7_vertical_sync_position = 255;
 
     let registers = Rc::new(RefCell::new(registers));
@@ -156,100 +125,59 @@ fn should_return_field_complete_true_at_max_lines() {
     assert_eq!(
         field_complete_iteration,
         crate::video::MAX_LINES as i32 - 1,
-        "field_complete should occur at iteration {}",
-        crate::video::MAX_LINES - 1
+        "field_complete should occur at iteration",
     );
 }
 
 #[test]
 fn should_stop_incrementing_addr_after_char_line_exceeds_vertical_total() {
     let mut registers = create_default_registers();
-    registers.crtc_r9_maximum_raster_address = 1;
-    registers.crtc_r4_vertical_total = 2;
-    registers.crtc_r1_horizontal_displayed = 50;
-    registers.crtc_r6_vertical_displayed = 2;
+    registers.crtc_r9_maximum_raster_address = 1; // 2 scanlines per character line
+    registers.crtc_r4_vertical_total = 2; // 3 character lines total (0-2)
+    registers.crtc_r1_horizontal_displayed = 50; // 0x32 per line
+    registers.crtc_r6_vertical_displayed = 2; // 2 character lines visible
     registers.crtc_r7_vertical_sync_position = 10;
 
     let registers = Rc::new(RefCell::new(registers));
     let mut crtc = setup_test(registers);
 
-    let results = collect_results(&mut crtc, 10);
-
-    let expected = vec![
-        ExpectedSnapshot {
-            address: Some(0x2000),
-            in_scan: Some(true),
-            scanline: Some(0),
-            raster_address_even: Some(0),
-            ..ExpectedSnapshot::default()
-        },
-        ExpectedSnapshot {
-            address: Some(0x2000),
-            in_scan: Some(true),
-            scanline: Some(1),
-            raster_address_even: Some(1),
-            ..ExpectedSnapshot::default()
-        },
-        ExpectedSnapshot {
-            address: Some(0x2032),
-            in_scan: Some(true),
-            scanline: Some(2),
-            raster_address_even: Some(0),
-            ..ExpectedSnapshot::default()
-        },
-        ExpectedSnapshot {
-            address: Some(0x2032),
-            in_scan: Some(true),
-            scanline: Some(3),
-            raster_address_even: Some(1),
-            ..ExpectedSnapshot::default()
-        },
-        ExpectedSnapshot {
-            address: Some(0x2064),
-            in_scan: Some(false),
-            scanline: Some(4),
-            raster_address_even: Some(0),
-            ..ExpectedSnapshot::default()
-        },
-        ExpectedSnapshot {
-            address: Some(0x2064),
-            in_scan: Some(false),
-            scanline: Some(5),
-            raster_address_even: Some(1),
-            ..ExpectedSnapshot::default()
-        },
-        ExpectedSnapshot {
-            address: Some(0x2000),
-            in_scan: Some(true),
-            scanline: Some(6),
-            raster_address_even: Some(0),
-            ..ExpectedSnapshot::default()
-        },
-        ExpectedSnapshot {
-            address: Some(0x2000),
-            in_scan: Some(true),
-            scanline: Some(7),
-            raster_address_even: Some(1),
-            ..ExpectedSnapshot::default()
-        },
-        ExpectedSnapshot {
-            address: Some(0x2032),
-            in_scan: Some(true),
-            scanline: Some(8),
-            raster_address_even: Some(0),
-            ..ExpectedSnapshot::default()
-        },
-        ExpectedSnapshot {
-            address: Some(0x2032),
-            in_scan: Some(true),
-            scanline: Some(9),
-            raster_address_even: Some(1),
-            ..ExpectedSnapshot::default()
-        },
+    // After char line 2 exceeds vertical_total (2), address remains at 0x2064
+    // until frame resets at scanline 6, then pattern repeats
+    let expected = [
+        // address, in_scan, scanline, raster_address_even
+        (0x2000, true, 0, 0),  // char line 0, raster 0
+        (0x2000, true, 1, 1),  // char line 0, raster 1
+        (0x2032, true, 2, 0),  // char line 1, raster 0
+        (0x2032, true, 3, 1),  // char line 1, raster 1
+        (0x2064, false, 4, 0), // char line 2, raster 0 (out of display)
+        (0x2064, false, 5, 1), // char line 2, raster 1 (address frozen)
+        (0x2000, true, 6, 0),  // frame reset
+        (0x2000, true, 7, 1),
+        (0x2032, true, 8, 0),
+        (0x2032, true, 9, 1),
     ];
 
-    for (actual, expected) in results.iter().zip(expected.iter()) {
-        assert_snapshot_matches(&actual.snapshot_params, expected);
+    for (index, (expected_address, expected_in_scan, expected_scanline, expected_raster)) in
+        expected.iter().enumerate()
+    {
+        let actual = crtc.advance_scanline().snapshot_params;
+
+        assert_eq!(
+            actual.address, *expected_address,
+            "address mismatch at index {index}",
+        );
+        assert_eq!(
+            actual.in_scan, *expected_in_scan,
+            "in_scan mismatch at index {index}",
+        );
+        assert_eq!(
+            actual.scanline, *expected_scanline,
+            "scanline mismatch at index {index}",
+        );
+        assert_eq!(
+            actual.raster_address_even, *expected_raster,
+            "raster_address_even mismatch at index {index}",
+        );
     }
 }
 
@@ -258,12 +186,13 @@ fn should_maintain_consistent_scanline_delta() {
     let registers = Rc::new(RefCell::new(create_default_registers()));
     let mut crtc = setup_test(registers);
 
-    let results = collect_results(&mut crtc, 50);
-    let scanlines: Vec<u16> = results.iter().map(|r| r.snapshot_params.scanline).collect();
-
     let expected_scanlines: Vec<u16> = (0..50).map(|i| i as u16).collect();
 
-    assert_eq!(scanlines, expected_scanlines);
+    for (index, expected) in expected_scanlines.iter().enumerate() {
+        let actual = crtc.advance_scanline().snapshot_params.scanline;
+
+        assert_eq!(actual, *expected, "mismatch at index {index}");
+    }
 }
 
 #[test]
@@ -275,26 +204,28 @@ fn should_track_raster_address_progression_correctly() {
     let registers = Rc::new(RefCell::new(registers));
     let mut crtc = setup_test(registers);
 
-    let results = collect_results(&mut crtc, 12);
-    let raster_addresses: Vec<u8> = results
-        .iter()
-        .map(|r| r.snapshot_params.raster_address_even)
-        .collect();
+    let expected_pattern = [0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3];
 
-    let expected_pattern: Vec<u8> = vec![0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3];
+    for (index, expected) in expected_pattern.iter().enumerate() {
+        let actual = crtc.advance_scanline().snapshot_params.raster_address_even;
 
-    assert_eq!(raster_addresses, expected_pattern);
+        assert_eq!(actual, *expected, "mismatch at index {index}");
+    }
 }
 
 #[test]
 fn should_trigger_vsync_at_correct_positions() {
-    let test_cases = vec![
-        (1, 0x00, vec![], 10),
-        (2, 0x10, vec![4], 15),
-        (2, 0x20, vec![4, 5], 20),
-        (3, 0x20, vec![6, 7], 20),
-        (2, 0x30, vec![4, 5, 6], 20),
-        (2, 0x40, vec![4, 5, 6, 7], 15),
+    // Test vsync triggering: vsync starts at char_line * scanlines_per_char,
+    // continues for (sync_width >> 4) scanlines.
+    // With r9=1 (2 scanlines/char): char_line N starts at scanline N*2
+    let test_cases = [
+        // r7_vertical_sync_position, r3_sync_width, expected_indices, length
+        (1, 0x00, vec![], 10), // vsync at char 1 (scanline 2), width=0: no vsync
+        (2, 0x10, vec![4], 15), // vsync at char 2 (scanline 4), width=1
+        (2, 0x20, vec![4, 5], 20), // vsync at char 2 (scanline 4), width=2
+        (3, 0x20, vec![6, 7], 20), // vsync at char 3 (scanline 6), width=2
+        (2, 0x30, vec![4, 5, 6], 20), // vsync at char 2 (scanline 4), width=3
+        (2, 0x40, vec![4, 5, 6, 7], 15), // vsync at char 2 (scanline 4), width=4
     ];
 
     for (r7_vertical_sync_position, r3_sync_width, expected_indices, length) in test_cases {
@@ -307,38 +238,41 @@ fn should_trigger_vsync_at_correct_positions() {
         let registers = Rc::new(RefCell::new(registers));
         let mut crtc = setup_test(registers);
 
-        let results = collect_results(&mut crtc, length);
-        let vsync_values: Vec<bool> = results.iter().map(|r| r.vsync).collect();
+        for index in 0..length {
+            let actual = crtc.advance_scanline().vsync;
+            let expected = expected_indices.contains(&index);
 
-        let expected: Vec<bool> = (0..length).map(|i| expected_indices.contains(&i)).collect();
-
-        assert_eq!(vsync_values, expected);
+            assert_eq!(
+                actual, expected,
+                "vsync mismatch at index {index} for r7_vertical_sync_position={}, r3_sync_width={:#04x}",
+                r7_vertical_sync_position, r3_sync_width
+            );
+        }
     }
 }
 
 #[test]
 fn should_complete_frame_at_correct_boundary() {
     let mut registers = create_default_registers();
-    registers.crtc_r9_maximum_raster_address = 1;
-    registers.crtc_r4_vertical_total = 2;
+    registers.crtc_r9_maximum_raster_address = 1; // 2 scanlines per char line
+    registers.crtc_r4_vertical_total = 2; // 3 char lines (0-2)
     registers.crtc_r5_vertical_total_adjust = 0;
 
     let registers = Rc::new(RefCell::new(registers));
     let mut crtc = setup_test(registers);
 
-    let results = collect_results(&mut crtc, 8);
-    let addresses: Vec<u16> = results.iter().map(|r| r.snapshot_params.address).collect();
-    let start_address = addresses[0];
+    // Frame = 3 char lines * 2 scanlines = 6 scanlines total.
+    // Address increments by 0x50 (default horizontal_displayed=80) per char line.
+    // At scanline 6, frame completes and address resets to start (0x2000)
+    let expected_addresses = [
+        0x2000, 0x2000, 0x2050, 0x2050, 0x20a0, 0x20a0, 0x2000, 0x2000,
+    ];
 
-    let mut reset_iteration: i32 = -1;
-    for i in 1..addresses.len() {
-        if addresses[i] == start_address && i > 4 {
-            reset_iteration = i as i32;
-            break;
-        }
+    for (index, expected) in expected_addresses.iter().enumerate() {
+        let actual = crtc.advance_scanline().snapshot_params.address;
+
+        assert_eq!(actual, *expected, "mismatch at index {index}");
     }
-
-    assert_eq!(reset_iteration, 6, "Address should reset at iteration 6");
 }
 
 #[test]
@@ -346,110 +280,85 @@ fn should_reset_scanline_after_field_complete() {
     let registers = Rc::new(RefCell::new(create_default_registers()));
     let mut crtc = setup_test(registers);
 
-    let results = collect_results(&mut crtc, 165);
-
-    let mut field_complete_index: i32 = -1;
-    for (i, result) in results.iter().enumerate() {
-        if result.field_complete {
-            field_complete_index = i as i32;
-            break;
-        }
+    // Advance to iteration 160 where field_complete should occur
+    for iteration in 0..160 {
+        let result = crtc.advance_scanline();
+        assert!(
+            !result.field_complete,
+            "field_complete should be false before iteration 160 ({iteration})"
+        );
     }
 
-    assert_eq!(field_complete_index, 160);
+    // At iteration 160: field_complete should be true and scanline should be 160
+    let result_at_160 = crtc.advance_scanline();
+    assert!(
+        result_at_160.field_complete,
+        "field_complete should be true at iteration 160"
+    );
+    assert_eq!(
+        result_at_160.snapshot_params.scanline, 160,
+        "scanline should be 160 at field_complete"
+    );
 
-    let scanline_at_field_complete = results[field_complete_index as usize]
-        .snapshot_params
-        .scanline;
-    assert_eq!(scanline_at_field_complete, 160);
-
-    let scanline_after_reset = results[field_complete_index as usize + 1]
-        .snapshot_params
-        .scanline;
-    assert_eq!(scanline_after_reset, 0);
+    // At iteration 161: scanline should reset to 0
+    let result_at_161 = crtc.advance_scanline();
+    assert_eq!(
+        result_at_161.snapshot_params.scanline, 0,
+        "scanline should reset to 0 after field_complete"
+    );
 }
 
 #[test]
 fn should_respect_vertical_total_adjust_when_completing_frames() {
     let mut registers = create_default_registers();
-    registers.crtc_r9_maximum_raster_address = 1;
-    registers.crtc_r4_vertical_total = 2;
-    registers.crtc_r5_vertical_total_adjust = 3;
-    registers.crtc_r1_horizontal_displayed = 50;
+    registers.crtc_r9_maximum_raster_address = 1; // 2 scanlines per char line
+    registers.crtc_r4_vertical_total = 2; // 3 char lines
+    registers.crtc_r5_vertical_total_adjust = 3; // +3 extra scanlines at end
+    registers.crtc_r1_horizontal_displayed = 50; // 0x32
     registers.crtc_r6_vertical_displayed = 2;
     registers.crtc_r7_vertical_sync_position = 0;
 
     let registers = Rc::new(RefCell::new(registers));
     let mut crtc = setup_test(registers);
 
-    let results = collect_results(&mut crtc, 12);
-
-    let expected = vec![
-        ExpectedSnapshot {
-            address: Some(0x2000),
-            in_scan: Some(true),
-            ..ExpectedSnapshot::default()
-        },
-        ExpectedSnapshot {
-            address: Some(0x2000),
-            in_scan: Some(true),
-            ..ExpectedSnapshot::default()
-        },
-        ExpectedSnapshot {
-            address: Some(0x2032),
-            in_scan: Some(true),
-            ..ExpectedSnapshot::default()
-        },
-        ExpectedSnapshot {
-            address: Some(0x2032),
-            in_scan: Some(true),
-            ..ExpectedSnapshot::default()
-        },
-        ExpectedSnapshot {
-            address: Some(0x2064),
-            in_scan: Some(false),
-            ..ExpectedSnapshot::default()
-        },
-        ExpectedSnapshot {
-            address: Some(0x2064),
-            in_scan: Some(false),
-            ..ExpectedSnapshot::default()
-        },
-        ExpectedSnapshot {
-            address: Some(0x2096),
-            in_scan: Some(false),
-            ..ExpectedSnapshot::default()
-        },
-        ExpectedSnapshot {
-            address: Some(0x2096),
-            in_scan: Some(false),
-            ..ExpectedSnapshot::default()
-        },
-        ExpectedSnapshot {
-            address: Some(0x2096),
-            in_scan: Some(false),
-            ..ExpectedSnapshot::default()
-        },
-        ExpectedSnapshot {
-            address: Some(0x2000),
-            in_scan: Some(true),
-            ..ExpectedSnapshot::default()
-        },
-        ExpectedSnapshot {
-            address: Some(0x2000),
-            in_scan: Some(true),
-            ..ExpectedSnapshot::default()
-        },
+    // Frame = (3 char lines * 2 scanlines) + 3 adjust = 9 scanlines total.
+    // Address increments stop after char lines complete, but scanlines continue.
+    // During the 3 adjust scanlines (6-8), address stays at 0x2096
+    let expected = [
+        // address, inScan
+        (0x2000, true),  // char line 0, scanline 0
+        (0x2000, true),  // char line 0, scanline 1
+        (0x2032, true),  // char line 1, scanline 2
+        (0x2032, true),  // char line 1, scanline 3
+        (0x2064, false), // char line 2, scanline 4
+        (0x2064, false), // char line 2, scanline 5
+        (0x2096, false), // adjust scanline 6 (address frozen)
+        (0x2096, false), // adjust scanline 7 (address frozen)
+        (0x2096, false), // adjust scanline 8 (address frozen)
+        (0x2000, true),  // frame reset, scanline 9
+        (0x2000, true),
     ];
 
-    for (actual, expected) in results.iter().zip(expected.iter()) {
-        assert_snapshot_matches(&actual.snapshot_params, expected);
+    for (index, (expected_address, expected_in_scan)) in expected.iter().enumerate() {
+        let actual = crtc.advance_scanline().snapshot_params;
+
+        assert_eq!(
+            actual.in_scan, *expected_in_scan,
+            "in_scan mismatch at index {index}",
+        );
+        assert_eq!(
+            actual.address, *expected_address,
+            "address mismatch at index {index}",
+        );
     }
 }
 
 #[test]
 fn should_maintain_consistent_next_scanline_trigger_in_both_frequency_modes() {
-    let test_cases = vec![(0x00, 256u16), (0x10, 128u16)];
+    // ula_control bit 4 selects frequency: 0=normal, 1=high
+    // Trigger = (horizontal_total + 1) * clock_divisor
+    // Normal mode: (127+1) * 2 = 256, High freq: (127+1) * 1 = 128
+    let test_cases = [(0x00, 256u16), (0x10, 128u16)];
 
     for (ula_control, expected_trigger) in test_cases {
         let mut registers = create_default_registers();
@@ -459,11 +368,13 @@ fn should_maintain_consistent_next_scanline_trigger_in_both_frequency_modes() {
         let registers = Rc::new(RefCell::new(registers));
         let mut crtc = setup_test(registers);
 
-        let results = collect_results(&mut crtc, 20);
-        let triggers: Vec<u16> = results.iter().map(|r| r.next_scanline_trigger).collect();
-        let expected_triggers = vec![expected_trigger; 20];
+        let expected_triggers = [expected_trigger; 20];
 
-        assert_eq!(triggers, expected_triggers);
+        for (index, expected) in expected_triggers.iter().enumerate() {
+            let actual = crtc.advance_scanline().next_scanline_trigger;
+
+            assert_eq!(actual, *expected, "mismatch at index {index}");
+        }
     }
 }
 
@@ -472,101 +383,74 @@ fn field_complete_should_only_occur_at_boundaries() {
     let registers = Rc::new(RefCell::new(create_default_registers()));
     let mut crtc = setup_test(registers);
 
-    let results = collect_results(&mut crtc, 165);
+    // With default registers: 20 char lines displayed * 8 scanlines/char = 160 scanlines
+    // field_complete should occur exactly once at scanline 160
+    for iteration in 0..165 {
+        let actual_field_complete = crtc.advance_scanline().field_complete;
+        let expected_field_complete = iteration == 160;
 
-    let field_complete_indices: Vec<usize> = results
-        .iter()
-        .enumerate()
-        .filter_map(|(i, r)| if r.field_complete { Some(i) } else { None })
-        .collect();
-
-    assert_eq!(field_complete_indices.len(), 1);
-    assert_eq!(field_complete_indices[0], 160);
+        assert_eq!(
+            actual_field_complete, expected_field_complete,
+            "mismatch at iteration {iteration}"
+        );
+    }
 }
 
 #[test]
 fn address_should_increment_by_horizontal_displayed_per_char_line() {
     let mut registers = create_default_registers();
-    registers.crtc_r1_horizontal_displayed = 40;
-    registers.crtc_r9_maximum_raster_address = 1;
+    registers.crtc_r1_horizontal_displayed = 0x28;
+    registers.crtc_r9_maximum_raster_address = 1; // 2 scanlines per char line
     registers.crtc_r4_vertical_total = 10;
 
     let registers = Rc::new(RefCell::new(registers));
     let mut crtc = setup_test(registers);
 
-    let results = collect_results(&mut crtc, 6);
-    let addresses: Vec<u16> = results.iter().map(|r| r.snapshot_params.address).collect();
+    // Address advances by horizontal_displayed (0x28) after each char line completes
+    let expected_addresses = [0x2000, 0x2000, 0x2028, 0x2028, 0x2050, 0x2050];
 
-    let expected_addresses: Vec<u16> = vec![0x2000, 0x2000, 0x2028, 0x2028, 0x2050, 0x2050];
+    for (index, expected) in expected_addresses.iter().enumerate() {
+        let actual = crtc.advance_scanline().snapshot_params.address;
 
-    assert_eq!(addresses, expected_addresses);
+        assert_eq!(actual, *expected, "mismatch at index {index}");
+    }
 }
 
 #[test]
 fn raster_address_odd_should_equal_even_plus_one_when_interlaced() {
     let mut registers = create_default_registers();
-    registers.crtc_r8_interlace_and_skew = 0x03;
+    registers.crtc_r8_interlace_and_skew = 0x03; // Interlace mode enabled
 
     let registers = Rc::new(RefCell::new(registers));
     let mut crtc = setup_test(registers);
 
-    let results = collect_results(&mut crtc, 10);
+    // In interlace mode, odd field raster addresses are offset by +1 from even field
 
-    let expected = vec![
-        ExpectedSnapshot {
-            raster_address_even: Some(0),
-            raster_address_odd: Some(1),
-            ..ExpectedSnapshot::default()
-        },
-        ExpectedSnapshot {
-            raster_address_even: Some(2),
-            raster_address_odd: Some(3),
-            ..ExpectedSnapshot::default()
-        },
-        ExpectedSnapshot {
-            raster_address_even: Some(4),
-            raster_address_odd: Some(5),
-            ..ExpectedSnapshot::default()
-        },
-        ExpectedSnapshot {
-            raster_address_even: Some(6),
-            raster_address_odd: Some(7),
-            ..ExpectedSnapshot::default()
-        },
-        ExpectedSnapshot {
-            raster_address_even: Some(0),
-            raster_address_odd: Some(1),
-            ..ExpectedSnapshot::default()
-        },
-        ExpectedSnapshot {
-            raster_address_even: Some(2),
-            raster_address_odd: Some(3),
-            ..ExpectedSnapshot::default()
-        },
-        ExpectedSnapshot {
-            raster_address_even: Some(4),
-            raster_address_odd: Some(5),
-            ..ExpectedSnapshot::default()
-        },
-        ExpectedSnapshot {
-            raster_address_even: Some(6),
-            raster_address_odd: Some(7),
-            ..ExpectedSnapshot::default()
-        },
-        ExpectedSnapshot {
-            raster_address_even: Some(0),
-            raster_address_odd: Some(1),
-            ..ExpectedSnapshot::default()
-        },
-        ExpectedSnapshot {
-            raster_address_even: Some(2),
-            raster_address_odd: Some(3),
-            ..ExpectedSnapshot::default()
-        },
+    let expected = [
+        // raster_address_even, raster_address_odd
+        (0, 1),
+        (2, 3),
+        (4, 5),
+        (6, 7),
+        (0, 1),
+        (2, 3),
+        (4, 5),
+        (6, 7),
+        (0, 1),
+        (2, 3),
     ];
 
-    for (actual, expected) in results.iter().zip(expected.iter()) {
-        assert_snapshot_matches(&actual.snapshot_params, expected);
+    for (index, (expected_even, expected_odd)) in expected.iter().enumerate() {
+        let actual = crtc.advance_scanline().snapshot_params;
+
+        assert_eq!(
+            actual.raster_address_even, *expected_even,
+            "raster_address_even mismatch at index {index}",
+        );
+        assert_eq!(
+            actual.raster_address_odd, *expected_odd,
+            "raster_address_odd mismatch at index {index}",
+        );
     }
 }
 
@@ -578,63 +462,31 @@ fn raster_address_odd_should_equal_even_when_not_interlaced() {
     let registers = Rc::new(RefCell::new(registers));
     let mut crtc = setup_test(registers);
 
-    let results = collect_results(&mut crtc, 10);
-
-    let expected = vec![
-        ExpectedSnapshot {
-            raster_address_even: Some(0),
-            raster_address_odd: Some(0),
-            ..ExpectedSnapshot::default()
-        },
-        ExpectedSnapshot {
-            raster_address_even: Some(1),
-            raster_address_odd: Some(1),
-            ..ExpectedSnapshot::default()
-        },
-        ExpectedSnapshot {
-            raster_address_even: Some(2),
-            raster_address_odd: Some(2),
-            ..ExpectedSnapshot::default()
-        },
-        ExpectedSnapshot {
-            raster_address_even: Some(3),
-            raster_address_odd: Some(3),
-            ..ExpectedSnapshot::default()
-        },
-        ExpectedSnapshot {
-            raster_address_even: Some(4),
-            raster_address_odd: Some(4),
-            ..ExpectedSnapshot::default()
-        },
-        ExpectedSnapshot {
-            raster_address_even: Some(5),
-            raster_address_odd: Some(5),
-            ..ExpectedSnapshot::default()
-        },
-        ExpectedSnapshot {
-            raster_address_even: Some(6),
-            raster_address_odd: Some(6),
-            ..ExpectedSnapshot::default()
-        },
-        ExpectedSnapshot {
-            raster_address_even: Some(7),
-            raster_address_odd: Some(7),
-            ..ExpectedSnapshot::default()
-        },
-        ExpectedSnapshot {
-            raster_address_even: Some(0),
-            raster_address_odd: Some(0),
-            ..ExpectedSnapshot::default()
-        },
-        ExpectedSnapshot {
-            raster_address_even: Some(1),
-            raster_address_odd: Some(1),
-            ..ExpectedSnapshot::default()
-        },
+    let expected = [
+        // raster_address_even, raster_address_odd
+        (0, 0),
+        (1, 1),
+        (2, 2),
+        (3, 3),
+        (4, 4),
+        (5, 5),
+        (6, 6),
+        (7, 7),
+        (0, 0),
+        (1, 1),
     ];
 
-    for (actual, expected) in results.iter().zip(expected.iter()) {
-        assert_snapshot_matches(&actual.snapshot_params, expected);
+    for (index, (expected_even, expected_odd)) in expected.iter().enumerate() {
+        let actual = crtc.advance_scanline().snapshot_params;
+
+        assert_eq!(
+            actual.raster_address_even, *expected_even,
+            "raster_address_even mismatch at index {index}",
+        );
+        assert_eq!(
+            actual.raster_address_odd, *expected_odd,
+            "raster_address_odd mismatch at index {index}",
+        );
     }
 }
 
@@ -652,49 +504,53 @@ fn address_should_only_update_from_start_registers_at_frame_boundary() {
     let registers = Rc::new(RefCell::new(registers));
     let mut crtc = setup_test(registers.clone());
 
-    let first_results = collect_results(&mut crtc, 8);
-    let first_addresses: Vec<u16> = first_results
-        .iter()
-        .map(|r| r.snapshot_params.address)
-        .collect();
-    assert_eq!(
-        first_addresses,
-        vec![
-            0x2000, 0x2000, 0x2032, 0x2032, 0x2064, 0x2064, 0x2000, 0x2000
-        ]
-    );
+    let first_expected_addresses = [
+        0x2000, 0x2000, 0x2032, 0x2032, 0x2064, 0x2064, 0x2000, 0x2000,
+    ];
 
+    for (index, expected) in first_expected_addresses.iter().enumerate() {
+        let actual = crtc.advance_scanline().snapshot_params.address;
+
+        assert_eq!(
+            actual, *expected,
+            "mismatch at index {index} (first sequence)"
+        );
+    }
+
+    // Change start address register mid-test
     registers.borrow_mut().crtc_r12_start_address_h = 0x30;
-    let second_results = collect_results(&mut crtc, 6);
-    let second_addresses: Vec<u16> = second_results
-        .iter()
-        .map(|r| r.snapshot_params.address)
-        .collect();
-    assert_eq!(
-        second_addresses,
-        vec![0x2032, 0x2032, 0x2064, 0x2064, 0x3000, 0x3000]
-    );
+
+    // Start address register change takes effect only at next frame boundary.
+    // Continues at 0x2032, 0x2064, then resets to new start 0x3000 at frame boundary
+    let second_expected_addresses = [0x2032, 0x2032, 0x2064, 0x2064, 0x3000, 0x3000];
+
+    for (index, expected) in second_expected_addresses.iter().enumerate() {
+        let actual = crtc.advance_scanline().snapshot_params.address;
+
+        assert_eq!(
+            actual, *expected,
+            "mismatch at index {index} (second sequence)"
+        );
+    }
 }
 
 #[test]
 fn should_handle_scan_lines_per_char_zero() {
     let mut registers = create_default_registers();
-    registers.crtc_r9_maximum_raster_address = 0;
+    registers.crtc_r9_maximum_raster_address = 0; // Edge case: 1 scanline per char
     registers.crtc_r6_vertical_displayed = 2;
     registers.crtc_r4_vertical_total = 5;
 
     let registers = Rc::new(RefCell::new(registers));
     let mut crtc = setup_test(registers);
 
-    let results = collect_results(&mut crtc, 5);
-    let raster_addresses: Vec<u8> = results
-        .iter()
-        .map(|r| r.snapshot_params.raster_address_even)
-        .collect();
+    let expected_addresses = [0, 0, 0, 0, 0];
 
-    let expected_addresses = vec![0, 0, 0, 0, 0];
+    for (index, expected) in expected_addresses.iter().enumerate() {
+        let actual = crtc.advance_scanline().snapshot_params.raster_address_even;
 
-    assert_eq!(raster_addresses, expected_addresses);
+        assert_eq!(actual, *expected, "mismatch at index {index}");
+    }
 }
 
 #[test]
@@ -707,40 +563,43 @@ fn should_handle_minimal_display_area() {
     let registers = Rc::new(RefCell::new(registers));
     let mut crtc = setup_test(registers);
 
-    let results = collect_results(&mut crtc, 5);
-    let in_scan_values: Vec<bool> = results.iter().map(|r| r.snapshot_params.in_scan).collect();
+    let expected_pattern = [true, true, false, false, false];
 
-    let expected_pattern = vec![true, true, false, false, false];
+    for (index, expected) in expected_pattern.iter().enumerate() {
+        let actual = crtc.advance_scanline().snapshot_params.in_scan;
 
-    assert_eq!(in_scan_values, expected_pattern);
+        assert_eq!(actual, *expected, "mismatch at index {index}");
+    }
 }
 
 #[test]
 fn should_handle_horizontal_total_zero() {
     let mut registers = create_default_registers();
-    registers.crtc_r0_horizontal_total = 0;
+    registers.crtc_r0_horizontal_total = 0; // Edge case: minimum value
     registers.ula_control = 0x00;
 
     let registers = Rc::new(RefCell::new(registers));
     let mut crtc = setup_test(registers);
 
-    let result = crtc.advance_scanline();
+    let actual = crtc.advance_scanline();
 
-    assert_eq!(result.next_scanline_trigger, 2);
+    // Trigger = (0 + 1) * 2 = 2
+    assert_eq!(actual.next_scanline_trigger, 2);
 }
 
 #[test]
 fn should_handle_horizontal_total_255() {
     let mut registers = create_default_registers();
-    registers.crtc_r0_horizontal_total = 255;
-    registers.ula_control = 0x10;
+    registers.crtc_r0_horizontal_total = 255; // Edge case: maximum value
+    registers.ula_control = 0x10; // High frequency mode
 
     let registers = Rc::new(RefCell::new(registers));
     let mut crtc = setup_test(registers);
 
-    let result = crtc.advance_scanline();
+    let actual = crtc.advance_scanline();
 
-    assert_eq!(result.next_scanline_trigger, 256);
+    // Trigger = (255 + 1) * 1 = 256 (high freq mode uses divisor 1)
+    assert_eq!(actual.next_scanline_trigger, 256);
 }
 
 #[test]
@@ -748,62 +607,71 @@ fn should_maintain_consistent_trigger_values_across_multiple_frames() {
     let mut registers = create_default_registers();
     registers.crtc_r0_horizontal_total = 127;
     registers.ula_control = 0x00;
-    registers.crtc_r9_maximum_raster_address = 1;
-    registers.crtc_r4_vertical_total = 2;
+    registers.crtc_r9_maximum_raster_address = 1; // 2 scanlines per char
+    registers.crtc_r4_vertical_total = 2; // 3 char lines
     registers.crtc_r5_vertical_total_adjust = 0;
 
     let registers = Rc::new(RefCell::new(registers));
     let mut crtc = setup_test(registers);
 
-    let frame_length = 3 * 2;
-    let results = collect_results(&mut crtc, frame_length * 2 + 5);
-    let triggers: Vec<u16> = results.iter().map(|r| r.next_scanline_trigger).collect();
+    // Frame = 3 char lines * 2 scanlines = 6 scanlines. Test 17 scanlines = 2.8 frames
+    // next_scanline_trigger should remain constant (256) throughout
+    let expected_triggers = [256u16; 17];
 
-    let expected_triggers = vec![256u16; 17];
+    for (index, expected) in expected_triggers.iter().enumerate() {
+        let actual = crtc.advance_scanline().next_scanline_trigger;
 
-    assert_eq!(triggers, expected_triggers);
+        assert_eq!(actual, *expected, "mismatch at index {index}");
+    }
 }
 
 #[test]
 fn should_show_pattern_stability_across_multiple_complete_frames() {
     let mut registers = create_default_registers();
-    registers.crtc_r9_maximum_raster_address = 1;
-    registers.crtc_r4_vertical_total = 2;
+    registers.crtc_r9_maximum_raster_address = 1; // 2 scanlines per char
+    registers.crtc_r4_vertical_total = 2; // 3 char lines
     registers.crtc_r5_vertical_total_adjust = 0;
     registers.crtc_r1_horizontal_displayed = 50;
 
     let registers = Rc::new(RefCell::new(registers));
     let mut crtc = setup_test(registers);
 
-    let frame_length = 3 * 2;
-    let results = collect_results(&mut crtc, frame_length * 3);
-    let scanlines: Vec<u16> = results.iter().map(|r| r.snapshot_params.scanline).collect();
+    // Frame = 3 char lines * 2 scanlines = 6 scanlines.
+    // Test 17 scanlines = 2 complete frames + 5 scanlines into 3rd frame.
+    // Scanline counter increments continuously without resetting
+    let expected_scanlines = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
 
-    let expected_scanlines: Vec<u16> = (0..18).map(|i| i as u16).collect();
+    for (index, expected) in expected_scanlines.iter().enumerate() {
+        let actual = crtc.advance_scanline().snapshot_params.scanline;
 
-    assert_eq!(scanlines, expected_scanlines);
+        assert_eq!(actual, *expected, "mismatch at index {index}");
+    }
 }
 
 #[test]
 fn should_toggle_interlace_frame_and_double_trigger_on_alternate_frames() {
     let mut registers = create_default_registers();
     registers.crtc_r9_maximum_raster_address = 1;
-    registers.crtc_r4_vertical_total = 1;
+    registers.crtc_r4_vertical_total = 1; // 2 char lines per frame
     registers.crtc_r5_vertical_total_adjust = 0;
     registers.crtc_r0_horizontal_total = 127;
     registers.ula_control = 0x00;
-    registers.crtc_r8_interlace_and_skew = 0x01;
+    registers.crtc_r8_interlace_and_skew = 0x01; // Interlace sync enabled
     registers.crtc_r7_vertical_sync_position = 0;
 
     let registers = Rc::new(RefCell::new(registers));
     let mut crtc = setup_test(registers);
 
-    let results = collect_results(&mut crtc, 13);
-    let triggers: Vec<u16> = results.iter().map(|r| r.next_scanline_trigger).collect();
-
-    let expected_triggers: Vec<u16> = vec![
+    // Frame = 2 char lines * 2 scanlines = 4 scanlines.
+    // In interlace sync mode, every 4th scanline (at char line 1 of odd frames)
+    // gets double trigger (512) for half-line offset. Pattern: 256,256,256,512,...
+    let expected_triggers = [
         256, 256, 256, 512, 256, 256, 256, 256, 256, 256, 256, 512, 256,
     ];
 
-    assert_eq!(triggers, expected_triggers);
+    for (index, expected) in expected_triggers.iter().enumerate() {
+        let actual = crtc.advance_scanline().next_scanline_trigger;
+
+        assert_eq!(actual, *expected, "mismatch at index {index}");
+    }
 }

--- a/ch22-core/src/video/crtc/tests.rs
+++ b/ch22-core/src/video/crtc/tests.rs
@@ -19,6 +19,10 @@ fn create_default_registers() -> VideoRegisters {
     }
 }
 
+// ============================================================================
+// BASIC SCANLINE BEHAVIOR
+// ============================================================================
+
 #[test]
 fn should_increment_scanline_by_1_on_each_call() {
     let registers = create_default_registers();
@@ -35,6 +39,10 @@ fn should_increment_scanline_by_1_on_each_call() {
         crtc.advance_scanline(&registers);
     }
 }
+
+// ============================================================================
+// ADDRESS BEHAVIOR
+// ============================================================================
 
 #[test]
 fn should_advance_address_by_horizontal_displayed_after_char_scanlines() {
@@ -58,60 +66,6 @@ fn should_advance_address_by_horizontal_displayed_after_char_scanlines() {
 
         crtc.advance_scanline(&registers);
     }
-}
-
-#[test]
-fn should_transition_in_scan_from_true_to_false_at_display_boundary() {
-    let mut registers = create_default_registers();
-    registers.crtc_r9_maximum_raster_address = 1; // 2 scanlines per character line
-    registers.crtc_r6_vertical_displayed = 2; // 2 character lines displayed
-    registers.crtc_r4_vertical_total = 10;
-
-    let mut crtc = Crtc::default();
-    crtc.init(&registers);
-
-    // in_scan is true for 2 char lines * 2 scanlines = 4 scanlines, then false
-    let expected_pattern = [true, true, true, true, false, false, false];
-
-    for (index, expected) in expected_pattern.iter().enumerate() {
-        let actual = crtc.get_snapshot_params(&registers).in_scan;
-
-        assert_eq!(actual, *expected, "mismatch at index {index}");
-
-        crtc.advance_scanline(&registers);
-    }
-}
-
-#[test]
-fn should_return_beam_scanline_0_at_max_lines() {
-    let mut registers = create_default_registers();
-    // Set vsync position to max to prevent normal field completion,
-    // forcing the hardware limit (MAX_LINES) to trigger instead
-    registers.crtc_r7_vertical_sync_position = 255;
-
-    let mut crtc = Crtc::default();
-    crtc.init(&registers);
-
-    // Skip iteration 0 (initial state with beam_scanline == 0)
-    crtc.advance_scanline(&registers);
-
-    let mut beam_scanline_0_iteration: i32 = -1;
-    for i in 1..(crate::video::MAX_LINES + 10) {
-        let beam_scanline = crtc.get_snapshot_params(&registers).beam_scanline;
-
-        if beam_scanline == 0 {
-            beam_scanline_0_iteration = i as i32;
-            break;
-        }
-
-        crtc.advance_scanline(&registers);
-    }
-
-    assert_eq!(
-        beam_scanline_0_iteration,
-        crate::video::MAX_LINES as i32,
-        "beam scanline should be 0 at iteration MAX_LINES (after hardware limit reset)",
-    );
 }
 
 #[test]
@@ -168,6 +122,10 @@ fn should_stop_incrementing_addr_after_char_line_exceeds_vertical_total() {
     }
 }
 
+// ============================================================================
+// RASTER ADDRESS BEHAVIOR
+// ============================================================================
+
 #[test]
 fn should_track_raster_address_progression_correctly() {
     // Test raster_address_even cycles correctly with various r9 values
@@ -198,6 +156,10 @@ fn should_track_raster_address_progression_correctly() {
         }
     }
 }
+
+// ============================================================================
+// VSYNC BEHAVIOR
+// ============================================================================
 
 #[test]
 fn should_trigger_vsync_at_correct_positions() {
@@ -239,6 +201,64 @@ fn should_trigger_vsync_at_correct_positions() {
     }
 }
 
+// ============================================================================
+// FRAME AND SCAN BEHAVIOR
+// ============================================================================
+
+#[test]
+fn should_transition_in_scan_from_true_to_false_at_display_boundary() {
+    let mut registers = create_default_registers();
+    registers.crtc_r9_maximum_raster_address = 1; // 2 scanlines per character line
+    registers.crtc_r6_vertical_displayed = 2; // 2 character lines displayed
+    registers.crtc_r4_vertical_total = 10;
+
+    let mut crtc = Crtc::default();
+    crtc.init(&registers);
+
+    // in_scan is true for 2 char lines * 2 scanlines = 4 scanlines, then false
+    let expected_pattern = [true, true, true, true, false, false, false];
+
+    for (index, expected) in expected_pattern.iter().enumerate() {
+        let actual = crtc.get_snapshot_params(&registers).in_scan;
+
+        assert_eq!(actual, *expected, "mismatch at index {index}");
+
+        crtc.advance_scanline(&registers);
+    }
+}
+
+#[test]
+fn should_return_beam_scanline_0_at_max_lines() {
+    let mut registers = create_default_registers();
+    // Set vsync position to max to prevent normal field completion,
+    // forcing the hardware limit (MAX_LINES) to trigger instead
+    registers.crtc_r7_vertical_sync_position = 255;
+
+    let mut crtc = Crtc::default();
+    crtc.init(&registers);
+
+    // Skip iteration 0 (initial state with beam_scanline == 0)
+    crtc.advance_scanline(&registers);
+
+    let mut beam_scanline_0_iteration: i32 = -1;
+    for i in 1..(crate::video::MAX_LINES + 10) {
+        let beam_scanline = crtc.get_snapshot_params(&registers).beam_scanline;
+
+        if beam_scanline == 0 {
+            beam_scanline_0_iteration = i as i32;
+            break;
+        }
+
+        crtc.advance_scanline(&registers);
+    }
+
+    assert_eq!(
+        beam_scanline_0_iteration,
+        crate::video::MAX_LINES as i32,
+        "beam scanline should be 0 at iteration MAX_LINES (after hardware limit reset)",
+    );
+}
+
 #[test]
 fn should_complete_frame_at_correct_boundary() {
     let mut registers = create_default_registers();
@@ -264,6 +284,10 @@ fn should_complete_frame_at_correct_boundary() {
         crtc.advance_scanline(&registers);
     }
 }
+
+// ============================================================================
+// BEAM RESET BEHAVIOR
+// ============================================================================
 
 #[test]
 fn should_reset_scanline_after_beam_reset() {
@@ -355,6 +379,10 @@ fn should_respect_vertical_total_adjust_when_completing_frames() {
         }
     }
 }
+
+// ============================================================================
+// TRIGGER AND FREQUENCY BEHAVIOR
+// ============================================================================
 
 #[test]
 fn should_maintain_consistent_next_scanline_trigger_in_both_frequency_modes() {
@@ -535,6 +563,10 @@ fn address_should_only_update_from_start_registers_at_frame_boundary() {
     }
 }
 
+// ============================================================================
+// EDGE CASES
+// ============================================================================
+
 #[test]
 fn should_handle_scan_lines_per_char_zero() {
     let mut registers = create_default_registers();
@@ -631,6 +663,10 @@ fn should_maintain_consistent_trigger_values_across_multiple_frames() {
         crtc.advance_scanline(&registers);
     }
 }
+
+// ============================================================================
+// INTERLACE BEHAVIOR
+// ============================================================================
 
 #[test]
 fn should_toggle_interlace_frame_and_double_trigger_on_alternate_frames() {

--- a/ch22-core/src/video/crtc/vsync_control.rs
+++ b/ch22-core/src/video/crtc/vsync_control.rs
@@ -1,0 +1,32 @@
+use crate::video::VideoRegisters;
+
+#[derive(Default)]
+pub struct VSyncControl {
+    line_countdown: u8,
+}
+
+impl VSyncControl {
+    pub fn reset(&mut self) {
+        self.line_countdown = 0;
+    }
+
+    pub fn start_vsync_period(&mut self, registers: &VideoRegisters) -> bool {
+        if self.is_in_vsync() {
+            false
+        } else {
+            self.line_countdown = registers.r3_v_sync_width();
+
+            true
+        }
+    }
+
+    pub fn advance_scanline(&mut self) {
+        if self.line_countdown > 0 {
+            self.line_countdown -= 1;
+        }
+    }
+
+    pub fn is_in_vsync(&self) -> bool {
+        self.line_countdown > 0
+    }
+}

--- a/ch22-core/src/video/field_data.rs
+++ b/ch22-core/src/video/field_data.rs
@@ -1,7 +1,7 @@
 use std::cmp::{max, min};
 
 use crate::video::{
-    FieldLine, VideoMemoryAccess, VideoRegisters, MAX_LINES,
+    FieldLine, MAX_LINES, VideoMemoryAccess, VideoRegisters,
     video_registers::{R8_CURSOR_DELAY_HIDDEN, R10CursorBlinkMode},
 };
 

--- a/ch22-core/src/video/field_data.rs
+++ b/ch22-core/src/video/field_data.rs
@@ -1,14 +1,12 @@
 use std::cmp::{max, min};
 
 use crate::video::{
-    FieldLine, VideoMemoryAccess, VideoRegisters,
+    FieldLine, VideoMemoryAccess, VideoRegisters, MAX_LINES,
     video_registers::{R8_CURSOR_DELAY_HIDDEN, R10CursorBlinkMode},
 };
 
 #[cfg(test)]
 mod tests;
-
-const MAX_LINES: usize = 320;
 
 #[repr(C, packed)]
 pub struct Field {

--- a/ch22-core/src/video/video_registers.rs
+++ b/ch22-core/src/video/video_registers.rs
@@ -53,8 +53,16 @@ impl VideoRegisters {
         self.ula_palette |= ((value & 0x0f) as u64) << shift;
     }
 
+    pub fn ula_is_high_frequency(&self) -> bool {
+        (self.ula_control & 0x10) != 0
+    }
+
     pub fn ula_is_teletext(&self) -> bool {
         (self.ula_control & 0x02) != 0
+    }
+
+    pub fn r3_v_sync_width(&self) -> u8 {
+        self.crtc_r3_sync_width >> 4
     }
 
     pub fn r3_h_sync_width(&self) -> u8 {
@@ -63,6 +71,10 @@ impl VideoRegisters {
 
     pub fn r8_is_crtc_screen_delay_no_output(&self) -> bool {
         self.crtc_r8_interlace_and_skew & 0x30 == 0x30
+    }
+
+    pub fn r8_is_interlace(&self) -> bool {
+        self.crtc_r8_interlace_and_skew & 0x01 == 0x01
     }
 
     pub fn r8_is_interlace_sync_and_video(&self) -> bool {
@@ -85,6 +97,10 @@ impl VideoRegisters {
 
     pub fn r10_r11_cursor_raster_range(&self) -> RangeInclusive<u8> {
         (self.crtc_r10_cursor_start_raster & 0x1f)..=self.crtc_r11_cursor_end_raster
+    }
+
+    pub fn r12_r13_screen_address(&self) -> u16 {
+        (self.crtc_r12_start_address_h as u16) << 8 | self.crtc_r13_start_address_l as u16
     }
 
     pub fn r14_r15_cursor_address(&self) -> u16 {

--- a/ch22-core/src/video/video_registers.rs
+++ b/ch22-core/src/video/video_registers.rs
@@ -85,6 +85,18 @@ impl VideoRegisters {
         (self.crtc_r8_interlace_and_skew & 0xc0) >> 6
     }
 
+    pub fn r8_r9_rasters_per_char(&self) -> u8 {
+        // r9 should only be 5 bit
+        debug_assert!(self.crtc_r9_maximum_raster_address <= 0x1F);
+
+        if self.r8_is_interlace_sync_and_video() {
+            debug_assert!(self.crtc_r9_maximum_raster_address & 0x01 == 0); // odd r9 not supported in interlace sync and video mode
+            (self.crtc_r9_maximum_raster_address >> 1) + 1
+        } else {
+            self.crtc_r9_maximum_raster_address + 1
+        }
+    }
+
     pub fn r10_cursor_blink_mode(&self) -> R10CursorBlinkMode {
         match self.crtc_r10_cursor_start_raster & 0x60 {
             0x00 => R10CursorBlinkMode::Solid,


### PR DESCRIPTION
This pull request introduces several improvements and refactors to the video subsystem and IO device handling in the project. The main changes include encapsulating video-related logic into a new `Video` struct, streamlining the video processing flow, and adding support for IO devices to react to vsync changes. The JavaScript IO device interface has also been extended to optionally handle vsync events, and the public API has been updated to reflect these changes.

**Video subsystem refactor and encapsulation:**

* Introduced a new `Video` struct in `ch22-core/src/video.rs` that encapsulates video field data, CRTC logic, video registers, field counter, vsync state, and scanline timing. All video-related logic is now managed through this struct, replacing scattered fields and methods in `Core`.
* Refactored `Core` in `ch22-core/src/system/core.rs` to use the new `Video` struct, removing obsolete fields and methods such as `video_field`, `field_counter`, and `video_registers`. Video device creation and scanline processing are now delegated to `Video`. [[1]](diffhunk://#diff-5d13bca7a590cac5e4abe005e2d51bb44f2a1a0bde6a0664b7eafceda2d3c3f3L22-R43) [[2]](diffhunk://#diff-5d13bca7a590cac5e4abe005e2d51bb44f2a1a0bde6a0664b7eafceda2d3c3f3L83-R103) [[3]](diffhunk://#diff-5d13bca7a590cac5e4abe005e2d51bb44f2a1a0bde6a0664b7eafceda2d3c3f3R121-R128)
* Updated the `SystemFfi` API in `ch22-core/src/system/system_ffi.rs` to use new video methods (`run_one_field`, `video_field_start`), and removed legacy functions for field counter and scanline snapshotting. [[1]](diffhunk://#diff-dc364216ba089ffe607a3f677f675b255eb712fb5333a31bab6030cd9afe5f97L33-L62) [[2]](diffhunk://#diff-dc364216ba089ffe607a3f677f675b255eb712fb5333a31bab6030cd9afe5f97L138-R118)

**IO device enhancements:**

* Added a new `on_vsync_change` callback to the IO device trait in `ch22-core/src/devices/io_device.rs`, allowing devices to respond to vsync changes. The `IOSpace` and `IODeviceList` were updated to propagate vsync events to all registered devices. [[1]](diffhunk://#diff-6164ae157b16247e6adf62e2e31784d7217a8a4e01ecd3546c99eee8251671d9R8) [[2]](diffhunk://#diff-d2e89843299f331ad1a5ed79b6ba6c6ecaaf729323e6212e9a24b8b3fd517b08R70-R75) [[3]](diffhunk://#diff-ed6aefff97c37981915d43ba8650aacfce18ad074bdbd67c09d0acdd6c31d9fbR90-R95)
* Extended the JavaScript IO device interface (`JsIODevice`) to optionally accept an `on_vsync_change` callback, and updated device instantiation and callback wiring accordingly. [[1]](diffhunk://#diff-bea0d161a2ad55d15bc7882f0b99db975849d2e468ebe5f50fc42493ff702e6fR13) [[2]](diffhunk://#diff-bea0d161a2ad55d15bc7882f0b99db975849d2e468ebe5f50fc42493ff702e6fR25) [[3]](diffhunk://#diff-bea0d161a2ad55d15bc7882f0b99db975849d2e468ebe5f50fc42493ff702e6fR51-R60) [[4]](diffhunk://#diff-bea0d161a2ad55d15bc7882f0b99db975849d2e468ebe5f50fc42493ff702e6fR72) [[5]](diffhunk://#diff-bea0d161a2ad55d15bc7882f0b99db975849d2e468ebe5f50fc42493ff702e6fR113-R118)

**Public API and documentation updates:**

* Updated the README to reflect the new video processing model, replacing cycle-based execution and scanline snapshotting with field-based rendering and vsync-aware device callbacks. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L125-R132) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L161-L184)
* Modified the JavaScript API for adding IO devices to support the optional `onVsyncChange` callback, and clarified callback signatures. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L78-R85) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R98)
* Removed obsolete video register access and scanline snapshot methods from the API and documentation. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L161-L184) [[2]](diffhunk://#diff-dc364216ba089ffe607a3f677f675b255eb712fb5333a31bab6030cd9afe5f97L151-L167)

**Other improvements:**

* Minor cleanup in imports and device configuration code to support the new video and IO device structure. [[1]](diffhunk://#diff-5d13bca7a590cac5e4abe005e2d51bb44f2a1a0bde6a0664b7eafceda2d3c3f3L1-R1) [[2]](diffhunk://#diff-5d13bca7a590cac5e4abe005e2d51bb44f2a1a0bde6a0664b7eafceda2d3c3f3L12-R12) [[3]](diffhunk://#diff-dc364216ba089ffe607a3f677f675b255eb712fb5333a31bab6030cd9afe5f97R76) [[4]](diffhunk://#diff-dc364216ba089ffe607a3f677f675b255eb712fb5333a31bab6030cd9afe5f97R97)

**Summary of most important changes:**

**Video subsystem refactor:**
- Introduced the `Video` struct to encapsulate all video processing logic, including field data, CRTC, registers, field counter, vsync, and scanline timing. All video operations are now routed through this struct.
- Refactored `Core` and `SystemFfi` to use the new video model, removing legacy field and scanline management methods and fields. [[1]](diffhunk://#diff-5d13bca7a590cac5e4abe005e2d51bb44f2a1a0bde6a0664b7eafceda2d3c3f3L22-R43) [[2]](diffhunk://#diff-5d13bca7a590cac5e4abe005e2d51bb44f2a1a0bde6a0664b7eafceda2d3c3f3L83-R103) [[3]](diffhunk://#diff-dc364216ba089ffe607a3f677f675b255eb712fb5333a31bab6030cd9afe5f97L33-L62) [[4]](diffhunk://#diff-dc364216ba089ffe607a3f677f675b255eb712fb5333a31bab6030cd9afe5f97L138-R118)

**IO device enhancements:**
- Added an `on_vsync_change` callback to the IO device trait and infrastructure, enabling devices to respond to vsync changes. [[1]](diffhunk://#diff-6164ae157b16247e6adf62e2e31784d7217a8a4e01ecd3546c99eee8251671d9R8) [[2]](diffhunk://#diff-d2e89843299f331ad1a5ed79b6ba6c6ecaaf729323e6212e9a24b8b3fd517b08R70-R75) [[3]](diffhunk://#diff-ed6aefff97c37981915d43ba8650aacfce18ad074bdbd67c09d0acdd6c31d9fbR90-R95)
- Extended `JsIODevice` to support the optional `on_vsync_change` callback, updating instantiation and callback handling. [[1]](diffhunk://#diff-bea0d161a2ad55d15bc7882f0b99db975849d2e468ebe5f50fc42493ff702e6fR13) [[2]](diffhunk://#diff-bea0d161a2ad55d15bc7882f0b99db975849d2e468ebe5f50fc42493ff702e6fR25) [[3]](diffhunk://#diff-bea0d161a2ad55d15bc7882f0b99db975849d2e468ebe5f50fc42493ff702e6fR51-R60) [[4]](diffhunk://#diff-bea0d161a2ad55d15bc7882f0b99db975849d2e468ebe5f50fc42493ff702e6fR72) [[5]](diffhunk://#diff-bea0d161a2ad55d15bc7882f0b99db975849d2e468ebe5f50fc42493ff702e6fR113-R118)

**Public API and documentation updates:**
- Updated the README and JavaScript API to reflect the new field-based rendering and vsync-aware device callbacks, and removed obsolete scanline and register methods. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L125-R132) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L161-L184) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L78-R85) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R98) [[5]](diffhunk://#diff-dc364216ba089ffe607a3f677f675b255eb712fb5333a31bab6030cd9afe5f97L151-L167)

**Other improvements:**
- Cleaned up imports and device configuration to support the new architecture. [[1]](diffhunk://#diff-5d13bca7a590cac5e4abe005e2d51bb44f2a1a0bde6a0664b7eafceda2d3c3f3L1-R1) [[2]](diffhunk://#diff-5d13bca7a590cac5e4abe005e2d51bb44f2a1a0bde6a0664b7eafceda2d3c3f3L12-R12) [[3]](diffhunk://#diff-dc364216ba089ffe607a3f677f675b255eb712fb5333a31bab6030cd9afe5f97R76) [[4]](diffhunk://#diff-dc364216ba089ffe607a3f677f675b255eb712fb5333a31bab6030cd9afe5f97R97)